### PR TITLE
Add Workshop tag to mark all resources deployed

### DIFF
--- a/PetAdoptions/cdk/pet_stack/app/pet_stack.ts
+++ b/PetAdoptions/cdk/pet_stack/app/pet_stack.ts
@@ -7,4 +7,5 @@ import { Services } from '../lib/services';
 const stackName = "Services";
 const app = new cdk.App();
 
-new Services(app, stackName);
+const stack = new Services(app, stackName);
+cdk.Tag.add(stack, 'Workshop', 'true');


### PR DESCRIPTION
Common tag for resources is useful when we need to create Resource Groups for all workshop resources