### PR TITLE
Fix Load test and troubleshooting

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -57,6 +57,20 @@ export class Services extends cdk.Stack {
             },
             removalPolicy:  RemovalPolicy.DESTROY
         });
+        
+        dynamodb_petadoption.metricConsumedReadCapacityUnits().createAlarm(this, 'ReadCapacityUnitsLimit-BasicAlarm', {
+          threshold: 240,
+          evaluationPeriods: 2,
+          period: cdk.Duration.minutes(1),
+          alarmName: `${dynamodb_petadoption.tableName}-ReadCapacityUnitsLimit-BasicAlarm`,
+        });
+        
+        dynamodb_petadoption.metricConsumedReadCapacityUnits().createAlarm(this, 'WriteCapacityUnitsLimit-BasicAlarm', {
+          threshold: 240,
+          evaluationPeriods: 2,
+          period: cdk.Duration.minutes(1),
+          alarmName: `${dynamodb_petadoption.tableName}-WriteCapacityUnitsLimit-BasicAlarm`,
+        });
 
         // Seeds the petadoptions dynamodb table with all data required
         new ddbseeder.Seeder(this, "ddb_seeder_petadoption", {

--- a/PetAdoptions/patches/ddb-billing-mode.patch
+++ b/PetAdoptions/patches/ddb-billing-mode.patch
@@ -1,13 +1,27 @@
 diff --git cdk/pet_stack/lib/services.ts cdk/pet_stack/lib/services.ts
-index 539aebe..6a764bb 100644
+index d469bbd..dc4a15a 100644
 --- cdk/pet_stack/lib/services.ts
 +++ cdk/pet_stack/lib/services.ts
-@@ -54,7 +54,8 @@ export class Services extends cdk.Stack {
-             sortKey: {
+@@ -55,21 +55,8 @@ export class Services extends cdk.Stack {
                  name: 'petid',
                  type: ddb.AttributeType.STRING
--            }
-+            },
+             },
+-            removalPolicy:  RemovalPolicy.DESTROY
+-        });
+-        
+-        dynamodb_petadoption.metricConsumedReadCapacityUnits().createAlarm(this, 'ReadCapacityUnitsLimit-BasicAlarm', {
+-          threshold: 240,
+-          evaluationPeriods: 2,
+-          period: cdk.Duration.minutes(1),
+-          alarmName: `${dynamodb_petadoption.tableName}-ReadCapacityUnitsLimit-BasicAlarm`,
+-        });
+-        
+-        dynamodb_petadoption.metricConsumedReadCapacityUnits().createAlarm(this, 'WriteCapacityUnitsLimit-BasicAlarm', {
+-          threshold: 240,
+-          evaluationPeriods: 2,
+-          period: cdk.Duration.minutes(1),
+-          alarmName: `${dynamodb_petadoption.tableName}-WriteCapacityUnitsLimit-BasicAlarm`,
++            removalPolicy:  RemovalPolicy.DESTROY,
 +            billingMode: ddb.BillingMode.PAY_PER_REQUEST
          });
  


### PR DESCRIPTION
### Impact

DDB Alarm are not fired anymore

### Root cause

DDB table creation through cdk is not creating default alarms  anymore ...

### Fix

Force default alarm creation in CDK and fix patch broken by commit : https://github.com/aws-samples/one-observability-demo/commit/87492949337bbea9b77d207712f45d1bdd4768bd#diff-4ef86c630bf3b38b49fe4a632ef5f618 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
