### PR TITLE
Added runtime missing dependency for

### DIFF
--- a/PetAdoptions/petsite/petsite/PetSite.csproj
+++ b/PetAdoptions/petsite/petsite/PetSite.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.5.1.6" />
     <PackageReference Include="AWSSDK.SQS" Version="3.5.0.7" />
     <PackageReference Include="AWSSDK.XRay" Version="3.5.1.6" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.0.7" />  
     <PackageReference Include="AWSXRayRecorder.Core" Version="2.9.0" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.1" />


### PR DESCRIPTION
pet  "Adoption" action (STS runtime dependency)

*Issue #, if available: #19 *

*Description of changes:*

Missing runtime dependency for using Service Account. Prevents an error when Adopting a pet in the petsite portal (missing dependency error).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
