### PR TITLE
Fix service traces name

### DIFF
--- a/PetAdoptions/petlistadoptions-go/main.go
+++ b/PetAdoptions/petlistadoptions-go/main.go
@@ -17,12 +17,13 @@ import (
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	//"go.opentelemetry.io/contrib/detectors/aws/ecs"
 	otelxray "go.opentelemetry.io/contrib/propagators/aws/xray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlphttp"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/semconv"
 )
 
 func init() {
@@ -53,12 +54,21 @@ func init() {
 
 	/*
 		ecsResourceDetector := new(ecs.ResourceDetector)
-		resource, err := ecsResourceDetector.Detect(ctx)
+		ecsResource, err := ecsResourceDetector.Detect(ctx)
+
+
 
 		if err != nil {
 			fmt.Println("ECS Resource detection error:", err)
 		}
-	*/
+	//*/
+
+	tracesNameResource, _ := resource.New(ctx,
+		resource.WithAttributes(
+			// the service name used to display traces in backends
+			semconv.ServiceNameKey.String("petlistadoptions"),
+		),
+	)
 
 	// Create a new TraceProvider struct passing in the config, the exporter
 	// and the ID Generator we want to use for our tracing
@@ -66,7 +76,8 @@ func init() {
 		sdktrace.WithConfig(cfg),
 		sdktrace.WithSyncer(exporter),
 		sdktrace.WithIDGenerator(idg),
-		//sdktrace.WithResource(resource),
+		sdktrace.WithResource(tracesNameResource),
+		//sdktrace.WithResource(ecsResource),
 	)
 	// Set the traceprovider and the propagator we want to use
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
ADOT traces by default will use the loadbalancer name. This fixes
with the service name.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
