### PR TITLE
Added healthcheck to Traffic Generator Service

### DIFF
--- a/PetAdoptions/trafficgenerator/trafficgenerator/Dockerfile
+++ b/PetAdoptions/trafficgenerator/trafficgenerator/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443

--- a/PetAdoptions/trafficgenerator/trafficgenerator/Program.cs
+++ b/PetAdoptions/trafficgenerator/trafficgenerator/Program.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.Hosting;
 
 namespace trafficgenerator
 {
@@ -12,12 +13,17 @@ namespace trafficgenerator
     {
         public static void Main(string[] args)
         {
+            CreateWebBuilder(args).Build().RunAsync();
             CreateHostBuilder(args).Build().Run();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureServices((hostContext, services) => { services.AddHostedService<Worker>(); })
+                .ConfigureServices((hostContext, services) => 
+                { 
+                    services.AddHostedService<Worker>(); 
+
+                })
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
                     var env = hostingContext.HostingEnvironment;
@@ -33,6 +39,16 @@ namespace trafficgenerator
                             configureSource.Optional = true;
                             configureSource.ReloadAfter = TimeSpan.FromMinutes(5);
                         });
+
+                    
                 });
+
+        public static IHostBuilder CreateWebBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(web => 
+                {
+                    web.UseStartup<Startup>();
+                });
+            
     }
 }

--- a/PetAdoptions/trafficgenerator/trafficgenerator/Startup.cs
+++ b/PetAdoptions/trafficgenerator/trafficgenerator/Startup.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace trafficgenerator
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHealthChecks().AddCheck("AlwaysGood",()=> HealthCheckResult.Healthy("All Good!"));
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHealthChecks("/health");
+            app.UseHealthChecks("/");
+
+        }
+    }
+}

--- a/PetAdoptions/trafficgenerator/trafficgenerator/trafficgenerator.csproj
+++ b/PetAdoptions/trafficgenerator/trafficgenerator/trafficgenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,7 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
+        <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />   
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.12" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.12" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Changed Traffic Generator image to allow Health Checks from the ECS Orchestrator and avoid the task to continuously restart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
