### PR TITLE
Introduce Memory leak in PayForAdoption

### DIFF
--- a/PetAdoptions/payforadoption-go/payforadoption/service.go
+++ b/PetAdoptions/payforadoption-go/payforadoption/service.go
@@ -2,6 +2,8 @@ package payforadoption
 
 import (
 	"context"
+	"errors"
+	"runtime"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -47,6 +49,7 @@ func (s service) HealthCheck(ctx context.Context) error {
 
 // /api/completeadoption logic
 func (s service) CompleteAdoption(ctx context.Context, petId, petType string) (Adoption, error) {
+	logger := log.With(s.logger, "method", "CompleteAdoption")
 
 	uuid, _ := uuid.NewV4()
 	a := Adoption{
@@ -56,13 +59,25 @@ func (s service) CompleteAdoption(ctx context.Context, petId, petType string) (A
 		AdoptionDate:  time.Now(),
 	}
 
+	// Introduce memory leaks for pettype bunnies. Sorry bunnies :)
+	if petType == "bunny" {
+		if s.repository.ErrorModeOn(ctx) {
+			level.Error(logger).Log("errorMode", "On")
+			memoryLeak()
+			return a, errors.New("Illegal memory allocation")
+		} else {
+			level.Error(logger).Log("errorMode", "Off")
+		}
+	}
+
 	if err := s.repository.CreateTransaction(ctx, a); err != nil {
-		logger := log.With(s.logger, "method", "CompleteAdoption")
 		level.Error(logger).Log("err", err)
 		return Adoption{}, err
 	}
 
-	return a, s.repository.UpdateAvailability(ctx, a)
+	err := s.repository.UpdateAvailability(ctx, a)
+
+	return a, err
 }
 
 func (s service) CleanupAdoptions(ctx context.Context) error {
@@ -85,4 +100,27 @@ func (s service) TriggerSeeding(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func memoryLeak() {
+
+	// loosing time
+	time.Sleep(time.Duration(1000 * time.Millisecond))
+
+	type T struct {
+		v [2 << 20]int
+		t *T
+	}
+
+	var finalizer = func(t *T) {}
+
+	var x, y T
+
+	// The SetFinalizer call makes x escape to heap.
+	runtime.SetFinalizer(&x, finalizer)
+
+	// The following line forms a cyclic reference
+	// group with two members, x and y.
+	// This causes x and y are not collectable.
+	x.t, y.t = &y, &x // y also escapes to heap.
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Deactivated by default and activated by an entry into SSM `/petstore/errormode1 => "true"/"false"`, this introduces a memory leak and slow responses times on complete adoption endpoint with only the `bunny pettype`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
