### PR TITLE
Preventive bump of log4j BOM to avoid CVE-2021-45046 and CVE-2021-45105

### DIFF
--- a/PetAdoptions/petsearch-java/build.gradle
+++ b/PetAdoptions/petsearch-java/build.gradle
@@ -17,6 +17,7 @@ ext {
     set('springCloudVersion', "Hoxton.SR10")
     set('testContainerVersion', '1.13.0')
     set('opentelemetryVersion', '1.3.0')
+    set('log4j2.version', '2.17.0')
 }
 
 dependencies {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The PetSearch Java microservice uses Spring Boot. As explained in the Spring blog post: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot, users of Spring Boot are only affected by this issue if they changed the default logging from logback to log4j. This is not the case for the PetSearch Java, and even if we have the log4j-api and log4j-to-slf4j in our dependency tree, they can't be used to exploit the vulnerability. As a preventive step this PR upgrades the log4j BOM to use version 2.17.0, which contains the security fix, as if by any means anyone changes the dependency in the future it will use a safe version instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
