### PR TITLE
Dependency updates for petsearch-java (latest OpenTelemetry API and Spring Boot versions)

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services/ecs-service.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services/ecs-service.ts
@@ -179,7 +179,7 @@ export abstract class EcsService extends cdk.Construct {
 
   private addOtelCollectorContainer(taskDefinition: ecs.FargateTaskDefinition, logging: ecs.AwsLogDriver) {
     taskDefinition.addContainer('aws-otel-collector', {
-        image: ecs.ContainerImage.fromRegistry('public.ecr.aws/aws-observability/aws-otel-collector:v0.14.1'),
+        image: ecs.ContainerImage.fromRegistry('public.ecr.aws/aws-observability/aws-otel-collector:v0.15.1'),
         memoryLimitMiB: 256,
         cpu: 256,
         command: ["--config", "/etc/ecs/ecs-xray.yaml"],

--- a/PetAdoptions/petsearch-java/Dockerfile
+++ b/PetAdoptions/petsearch-java/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.8-jdk15 as build
+FROM gradle:7.3-jdk17 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle
@@ -8,10 +8,10 @@ COPY ./settings.gradle ./settings.gradle
 ENV GRADLE_OPTS "-Dorg.gradle.daemon=false"
 RUN gradle build -DexcludeTags='integration'
 
-FROM amazoncorretto:15-alpine
+FROM amazoncorretto:17-alpine
 WORKDIR /app
 
-ADD https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.2.0/aws-opentelemetry-agent.jar /app/aws-opentelemetry-agent.jar
+ADD https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.9.0/aws-opentelemetry-agent.jar /app/aws-opentelemetry-agent.jar
 ENV JAVA_TOOL_OPTIONS "-javaagent:/app/aws-opentelemetry-agent.jar"
 
 ARG JAR_FILE=build/libs/\*.jar
@@ -20,6 +20,6 @@ COPY --from=build /app/${JAR_FILE} ./app.jar
 # OpenTelemetry agent configuration
 ENV OTEL_RESOURCE_ATTRIBUTES "service.name=PetSearch"
 ENV OTEL_IMR_EXPORT_INTERVAL "10000"
-ENV OTEL_EXPORTER_OTLP_ENDPOINT "http://localhost:55680"
+ENV OTEL_EXPORTER_OTLP_ENDPOINT "http://localhost:4317"
 
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/PetAdoptions/petsearch-java/build.gradle
+++ b/PetAdoptions/petsearch-java/build.gradle
@@ -1,29 +1,28 @@
 plugins {
-    id 'org.springframework.boot' version '2.3.8.RELEASE'
+    id 'org.springframework.boot' version '2.6.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }
 
 group = 'org.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '15'
+sourceCompatibility = '11'
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 ext {
-    set('springCloudVersion', "Hoxton.SR10")
-    set('testContainerVersion', '1.13.0')
-    set('opentelemetryVersion', '1.3.0')
+    set('springCloudAwsVersion', "2.3.3")
+    set('testContainerVersion', '1.16.2')
+    set('opentelemetryVersion', '1.9.1')
     set('log4j2.version', '2.17.0')
 }
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws'
-    implementation 'org.springframework.cloud:spring-cloud-aws-autoconfigure'
+    implementation "io.awspring.cloud:spring-cloud-starter-aws:${springCloudAwsVersion}"
+    implementation "io.awspring.cloud:spring-cloud-aws-autoconfigure:${springCloudAwsVersion}"
 
     implementation 'com.amazonaws:aws-java-sdk-core'
     implementation 'com.amazonaws:aws-java-sdk-s3'
@@ -33,24 +32,28 @@ dependencies {
 
     implementation "io.opentelemetry:opentelemetry-api"
     implementation "io.opentelemetry:opentelemetry-api-metrics"
+    implementation "io.opentelemetry:opentelemetry-extension-annotations"
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
     testImplementation "org.testcontainers:localstack:${testContainerVersion}"
     testImplementation "org.testcontainers:junit-jupiter:${testContainerVersion}"
-    testImplementation group: 'io.vavr', name: 'vavr-test', version: '0.10.3'
+    testImplementation group: 'io.vavr', name: 'vavr-test', version: '0.10.4'
 
 }
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-        mavenBom "com.amazonaws:aws-xray-recorder-sdk-bom:2.4.0"
+        mavenBom "com.amazonaws:aws-xray-recorder-sdk-bom:2.9.1"
         mavenBom "io.opentelemetry:opentelemetry-bom:${opentelemetryVersion}"
         mavenBom "io.opentelemetry:opentelemetry-bom-alpha:${opentelemetryVersion}-alpha"
-        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.11.946'
+        mavenBom 'com.amazonaws:aws-java-sdk-bom:1.12.131'
     }
+}
+
+jar { // https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives
+    enabled = false
 }
 
 test {

--- a/PetAdoptions/petsearch-java/docker-compose.yml
+++ b/PetAdoptions/petsearch-java/docker-compose.yml
@@ -65,7 +65,6 @@ services:
       "
         java -jar /app/app.jar \\
           --cloud.aws.region.static="eu-central-1" \\
-          --spring.autoconfigure.exclude="org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration" \\
           --aws.local.endpoint=http://localstack:4566
       "
 

--- a/PetAdoptions/petsearch-java/gradle/wrapper/gradle-wrapper.properties
+++ b/PetAdoptions/petsearch-java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/PetAdoptions/petsearch-java/src/main/java/ca/petsearch/WebConfig.java
+++ b/PetAdoptions/petsearch-java/src/main/java/ca/petsearch/WebConfig.java
@@ -59,8 +59,8 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     @Bean
-    public MetricEmitter metricEmitter(Tracer tracer) {
-        return new MetricEmitter(tracer);
+    public MetricEmitter metricEmitter() {
+        return new MetricEmitter();
     }
 
     @Bean

--- a/PetAdoptions/petsearch-java/src/main/resources/application.yml
+++ b/PetAdoptions/petsearch-java/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   application:
     name: petstore
-  autoconfigure:
-    exclude: org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration
 cloud:
   aws:
     region:

--- a/PetAdoptions/petsearch-java/src/test/resources/application-test.yml
+++ b/PetAdoptions/petsearch-java/src/test/resources/application-test.yml
@@ -2,8 +2,6 @@ spring:
   profiles: test, default
   main:
     allow-bean-definition-overriding: true
-  autoconfigure:
-    exclude: org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration
 cloud:
   aws:
     region:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update to Spring Boot version 2.6.2
- Update to AWS Otel collector 0.15.1
- Use awspring.io instead of Spring Cloud
- Remove usage of Tracer in MetricEmitter
- Add sample for @WithSpan annotation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
