### PR TITLE
Replaced Team Role for new EEv2

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -436,7 +436,7 @@ export class Services extends Stack {
             });
 
             c9env = new cloud9.CfnEnvironmentEC2(this,"CloudEnv",{
-                ownerArn: "arn:aws:iam::" + stack.account +":assumed-role/TeamRole/MasterKey",
+                ownerArn: "arn:aws:iam::" + stack.account +":assumed-role/WSParticipantRole/Participant",
                 instanceType: "t2.micro",
                 name: "observabilityworkshop",
                 subnetId: theVPC.privateSubnets[0].subnetId,


### PR DESCRIPTION
The purpose of this PR is to update the role name used for the internal AWS Account venting system.

No changes for self-deployment.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
