### PR TITLE
Removed CodeCommit clone from Cloud9

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -443,8 +443,8 @@ export class Services extends Stack {
                 connectionType: 'CONNECT_SSM',
                 repositories: [
                     {
-                        repositoryUrl: "https://git-codecommit." + region + ".amazonaws.com/v1/repos/event-source",
-                        pathComponent: "/codecommit/pet_stack"
+                        repositoryUrl: "https://github.com/aws-samples/one-observability-demo.git",
+                        pathComponent: "/one-observability-demo"
                     }
                 ]
             });


### PR DESCRIPTION
The purpose of this PR is to change the source repository available in the Cloud9 environment from the CodeCommit repository (removed now) to github.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
