### PR TITLE
Changed Petsite searching from capturing trace metadata to annotations

### DIFF
--- a/PetAdoptions/petsite/petsite/Controllers/HomeController.cs
+++ b/PetAdoptions/petsite/petsite/Controllers/HomeController.cs
@@ -142,9 +142,9 @@ namespace PetSite.Controllers
 
             AWSXRayRecorder.Instance.BeginSubsegment("Calling Search API");
 
-            AWSXRayRecorder.Instance.AddMetadata("PetType", selectedPetType);
-            AWSXRayRecorder.Instance.AddMetadata("PetId", petid);
-            AWSXRayRecorder.Instance.AddMetadata("PetColor", selectedPetColor);
+            AWSXRayRecorder.Instance.AddAnnotation("PetType", selectedPetType);
+            AWSXRayRecorder.Instance.AddAnnotation("PetId", petid);
+            AWSXRayRecorder.Instance.AddAnnotation("PetColor", selectedPetColor);
 
             
             Console.WriteLine(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

At the moment, searches for bunnies on on PetSearch service have a performance delay of 3 seconds. This is not easily cleanly / easily detectable in X-Ray. I have updated some trace metadata to annotation, which allows us to query and analyse trace data by Pet types and highlight this performance issues much better.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
