### PR TITLE
Update services.ts to set addonVersion

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -553,6 +553,7 @@ export class Services extends Stack {
         // NOTE: Amazon CloudWatch Observability Addon for CloudWatch Agent and Fluentbit
         const otelAddon = new eks.CfnAddon(this, 'otelObservabilityAddon', {
             addonName: 'amazon-cloudwatch-observability',
+            addonVersion: 'v1.2.0-eksbuild.1',
             clusterName: cluster.clusterName,
             // the properties below are optional
             resolveConflicts: 'OVERWRITE',


### PR DESCRIPTION
*Issue #, if available:* - N/A

*Description of changes:* - Sets an addonVersion to get past the CFN API error during the otelAddon API call


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
