### PR TITLE
increase volume size of C9 instance

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -62,7 +62,7 @@ Parameters:
   C9InstanceVolumeSize:
     Type: Number
     Description: The Size in GB of the Cloud9 Instance Volume.
-    Default: 30
+    Default: 100
 
   C9Image:
     Type: String


### PR DESCRIPTION
*Issue #, if available:* C9 volume is not big enough to run cdk bootstrap and npm i. 

*Description of changes:* Increasing size remediates this issue 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
