### PR TITLE
fix bug in cloud9-cfn.yaml : IMDSv1 EC2 metadata is deprecated in AL2023 (#272)

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -720,7 +720,8 @@ Resources:
             - !Sub SIZE=${C9InstanceVolumeSize}
             - !Sub REGION=${AWS::Region}
             - |
-              INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+              TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+              INSTANCEID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/instance-id 2> /dev/null)
               VOLUMEID=$(aws ec2 describe-instances \
                 --instance-id $INSTANCEID \
                 --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \


### PR DESCRIPTION
*Issue #, if available:* #272

*Description of changes:* Since Cloud9's default OS has moved from AL2 to AL2023, EC2 metadata retrieval via IMDSv1 became unavailable. It causes failure in deploying Cloud9 environment by cfn template and trouble in following steps described in workshop procedure in "Setup Cloud9 environment" section (https://catalog.us-east-1.prod.workshops.aws/workshops/31676d37-bbe9-4992-9cd1-ceae13c5116c/en-US/installation/setup-cloud9).
This PR modifies cfn template to use IMDSv2 to retrieve EC2 metadata to address with this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
