### PR TITLE
fix bug in cloud9-cfn.yaml : SSM bootstraping doesn't work due to IAM and resource creation order

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -720,6 +720,7 @@ Resources:
             - !Sub SIZE=${C9InstanceVolumeSize}
             - !Sub REGION=${AWS::Region}
             - |
+              unset AWS_SHARED_CREDENTIALS_FILE
               INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
               VOLUMEID=$(aws ec2 describe-instances \
                 --instance-id $INSTANCEID \
@@ -814,6 +815,7 @@ Resources:
 
 
   C9BootstrapAssociation:
+    DependsOn: C9BootstrapInstanceLambda
     Type: AWS::SSM::Association
     Properties:
       Name: !Ref C9SSMDocument
@@ -880,7 +882,6 @@ Resources:
       - Ref: C9Role
 
   C9Instance:
-    DependsOn: C9BootstrapAssociation
     Type: AWS::Cloud9::EnvironmentEC2
     Properties:
       Description: !Sub  AWS Cloud9 instance for ${EnvironmentName}


### PR DESCRIPTION
*Issue #, if available:* #272

*Description of changes:*
In some configuration, C9SSMDocument doesn't use IAM role attached as InstanceProfile hence `ResizeVolume` runCommand falls into infinite loop, and finally CFn stack creation fails. To avoid it, this commit modifies below:
- Force SSM runCommand to ignore IAM role configured in SSM default setting and use InstanceProfile
- Change resource creation order so that InstanceProfile is attached to C9 instance before SSM runCommand starts.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
