### PR TITLE
Move tools to correct directory

### DIFF
--- a/setup-cloudshell.sh
+++ b/setup-cloudshell.sh
@@ -10,7 +10,7 @@ function install_helm(){
 	curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 	chmod 700 get_helm.sh
 	./get_helm.sh
-	sudo mv $(which helm) $HOME/.local/bin
+	sudo mv $(which helm) $HOME/.local/bin/
 	rm get_helm.sh
 }
 
@@ -21,7 +21,7 @@ function install_eksctl(){
 	curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
 	curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
 	tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
-	sudo mv /tmp/eksctl $HOME/.local/bin
+	sudo mv /tmp/eksctl $HOME/.local/bin/
 }
 
 function install_awscurl(){
@@ -29,6 +29,7 @@ function install_awscurl(){
 	pip install awscurl
 }
 
+mkdir -p $HOME/.local/bin
 cd /tmp
 
 # install helm


### PR DESCRIPTION
Ensures we move the tools into the `bin` directory, and not a file named `bin`. Without this, we end up with a binary named `bin` which is actually eksctl. See picture. 

<img width="848" alt="Screenshot 2024-09-20 at 9 58 02 AM" src="https://github.com/user-attachments/assets/25a7fcdd-7dea-44bc-abae-6f449aa93be6">
