### PR TITLE
fix Kubectl layer issue and bump EKS and oTel addon version

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/applications.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/applications.ts
@@ -9,6 +9,7 @@ import { readFileSync } from 'fs';
 import { Construct } from 'constructs'
 import { ContainerImageBuilderProps, ContainerImageBuilder } from './common/container-image-builder'
 import { PetAdoptionsHistory } from './applications/pet-adoptions-history-application'
+import { KubectlV32Layer } from '@aws-cdk/lambda-layer-kubectl-v32';
 
 export class Applications extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -25,6 +26,7 @@ export class Applications extends Stack {
 
     const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
       clusterName: 'PetSite',
+      kubectlLayer: new KubectlV32Layer(this, 'kubectl'),
       kubectlRoleArn: roleArn,
     });
     // ClusterID is not available for creating the proper conditions https://github.com/aws/aws-cdk/issues/10347

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -31,7 +31,7 @@ import { CfnJson, RemovalPolicy, Fn, Duration, Stack, StackProps, CfnOutput } fr
 import { readFileSync } from 'fs';
 import 'ts-replace-all'
 import { TreatMissingData, ComparisonOperator } from 'aws-cdk-lib/aws-cloudwatch';
-import { KubectlLayer } from 'aws-cdk-lib/lambda-layer-kubectl';
+import { KubectlV32Layer } from '@aws-cdk/lambda-layer-kubectl-v32';
 
 export class Services extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
@@ -342,8 +342,8 @@ export class Services extends Stack {
             defaultCapacity: 2,
             defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MEDIUM),
             secretsEncryptionKey: secretsKey,
-            version: KubernetesVersion.of('1.31'),
-            kubectlLayer: new KubectlLayer(this, 'kubectl'),
+            version: eks.KubernetesVersion.V1_32,
+            kubectlLayer: new KubectlV32Layer(this, 'kubectl'),
             authenticationMode: eks.AuthenticationMode.API_AND_CONFIG_MAP,
         });
 
@@ -511,7 +511,7 @@ export class Services extends Stack {
         // NOTE: Amazon CloudWatch Observability Addon for CloudWatch Agent and Fluentbit
         const otelAddon = new eks.CfnAddon(this, 'otelObservabilityAddon', {
             addonName: 'amazon-cloudwatch-observability',
-            addonVersion: 'v2.6.0-eksbuild.1',
+            addonVersion: 'v3.3.0-eksbuild.1',
             clusterName: cluster.clusterName,
             // the properties below are optional
             resolveConflicts: 'OVERWRITE',

--- a/PetAdoptions/cdk/pet_stack/package.json
+++ b/PetAdoptions/cdk/pet_stack/package.json
@@ -12,23 +12,24 @@
     "cdk": "cdk"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.131.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.179.0-alpha.0",
+    "@aws-cdk/lambda-layer-kubectl-v32": "^2.0.3",
     "@types/js-yaml": "^4.0.9",
-    "aws-cdk-lib": "^2.146.0",
-    "cdk-ecr-deployment": "^3.0.67",
+    "aws-cdk-lib": "^2.179.0",
+    "cdk-ecr-deployment": "^3.1.9",
     "jest": "^29.7.0",
     "js-yaml": "^4.1.0",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.12",
-    "@types/node": "^20.14.2",
-    "aws-cdk": "^2.146.0",
-    "cdk-nag": "^2.28.144",
-    "constructs": "^10.3.0",
-    "ts-jest": "^29.1.5",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.13.4",
+    "aws-cdk": "^2.1000.2",
+    "cdk-nag": "^2.35.24",
+    "constructs": "^10.4.2",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "ts-replace-all": "^1.0.0",
-    "typescript": "^5.4.5"
+    "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
*Description of changes:*
- Bumping EKS version to 1.32
- Bumping oTel addon version to v3.3.0-eksbuild.1
- Update the `kubectlLayer` to  `kubectlLayer-v32` due to deprecation of default value for `kubectlLayer`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
