### PR TITLE
add IAM role, add-ons for Network Flow Monitor setup on EKS

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -521,6 +521,53 @@ export class Services extends Stack {
             serviceAccountRoleArn: cwserviceaccount.roleArn,
           });
 
+        // IAM Role for Network Flow Monitor
+        const networkFlowMonitorRole = new iam.CfnRole(this, 'NetworkFlowMonitorRole', {
+            roleName: 'network-flow-monitor-demo-role',
+            assumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Principal: {
+                    Service: 'pods.eks.amazonaws.com',
+                  },
+                  Action: [
+                    'sts:AssumeRole',
+                    'sts:TagSession',
+                  ],
+                },
+              ],
+            },
+            managedPolicyArns: [
+              'arn:aws:iam::aws:policy/CloudWatchNetworkFlowMonitorAgentPublishPolicy',
+            ],
+          });
+
+        // Amazon EKS Pod Identity Agent Addon for Network Flow Monitor
+        const podIdentityAgentAddon = new eks.CfnAddon(this, 'PodIdentityAgentAddon', {
+            addonName: 'eks-pod-identity-agent',
+            addonVersion: 'v1.3.4-eksbuild.1',
+            clusterName: cluster.clusterName,
+            resolveConflicts: 'OVERWRITE',
+            preserveOnDelete: false,
+          });
+
+        // Amazon EKS AWS Network Flow Monitor Agent add-on
+        const networkFlowMonitoringAgentAddon = new eks.CfnAddon(this, 'NetworkFlowMonitoringAgentAddon', {
+            addonName: 'aws-network-flow-monitoring-agent',
+            addonVersion: 'v1.0.1-eksbuild.2',
+            clusterName: 'PetSite',
+            resolveConflicts: 'OVERWRITE',
+            preserveOnDelete: false,
+            podIdentityAssociations: [
+              {
+                roleArn: networkFlowMonitorRole.attrArn,
+                serviceAccount: 'aws-network-flow-monitor-agent-service-account',
+              },
+            ],
+          });
+
         const customWidgetResourceControllerPolicy = new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,
             actions: [
@@ -614,6 +661,7 @@ export class Services extends Stack {
 
         this.createOuputs(new Map(Object.entries({
             'CWServiceAccountArn': cwserviceaccount.roleArn,
+            'NetworkFlowMonitorServiceAccountArn': networkFlowMonitorRole.attrArn,
             'XRayServiceAccountArn': xrayserviceaccount.roleArn,
             'OIDCProviderUrl': cluster.clusterOpenIdConnectIssuerUrl,
             'OIDCProviderArn': cluster.openIdConnectProvider.openIdConnectProviderArn,

--- a/PetAdoptions/cdk/pet_stack/resources/destroy_stack.sh
+++ b/PetAdoptions/cdk/pet_stack/resources/destroy_stack.sh
@@ -13,6 +13,14 @@ fi
 DDB_CONTRIB=$(aws ssm get-parameter --name '/petstore/dynamodbtablename' | jq .Parameter.Value -r)
 aws dynamodb update-contributor-insights --table-name $DDB_CONTRIB --contributor-insights-action DISABLE
 
+# Delete Network Flow Monitor
+if aws networkflowmonitor get-monitor --monitor-name network-flow-monitor-demo >/dev/null 2>&1; then
+    echo "Deleting network flow monitor..."
+    aws networkflowmonitor delete-monitor --monitor-name network-flow-monitor-demo
+else
+    echo "Network flow monitor not found, skipping delete."
+fi
+
 echo STARTING SERVICES CLEANUP
 echo -----------------------------
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding 
- IAM Role
- eks-pod-identity-agent and 
- aws-network-flow-monitoring-agent to EKS Cluster

as part of Network Flow Monitor demo

Ref: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-kubernetes-eks.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
