### PR TITLE
Downgrade EKS version to 1.31 to support adot addon installation

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/applications.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/applications.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { Construct } from 'constructs'
 import { ContainerImageBuilderProps, ContainerImageBuilder } from './common/container-image-builder'
 import { PetAdoptionsHistory } from './applications/pet-adoptions-history-application'
-import { KubectlV32Layer } from '@aws-cdk/lambda-layer-kubectl-v32';
+import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
 
 export class Applications extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -26,7 +26,7 @@ export class Applications extends Stack {
 
     const cluster = eks.Cluster.fromClusterAttributes(this, 'MyCluster', {
       clusterName: 'PetSite',
-      kubectlLayer: new KubectlV32Layer(this, 'kubectl'),
+      kubectlLayer: new KubectlV31Layer(this, 'kubectl'),
       kubectlRoleArn: roleArn,
     });
     // ClusterID is not available for creating the proper conditions https://github.com/aws/aws-cdk/issues/10347

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -31,7 +31,7 @@ import { CfnJson, RemovalPolicy, Fn, Duration, Stack, StackProps, CfnOutput } fr
 import { readFileSync } from 'fs';
 import 'ts-replace-all'
 import { TreatMissingData, ComparisonOperator } from 'aws-cdk-lib/aws-cloudwatch';
-import { KubectlV32Layer } from '@aws-cdk/lambda-layer-kubectl-v32';
+import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
 
 export class Services extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
@@ -344,8 +344,8 @@ export class Services extends Stack {
             defaultCapacity: 2,
             defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MEDIUM),
             secretsEncryptionKey: secretsKey,
-            version: eks.KubernetesVersion.V1_32,
-            kubectlLayer: new KubectlV32Layer(this, 'kubectl'),
+            version: eks.KubernetesVersion.V1_31,
+            kubectlLayer: new KubectlV31Layer(this, 'kubectl'),
             authenticationMode: eks.AuthenticationMode.API_AND_CONFIG_MAP,
         });
 

--- a/PetAdoptions/cdk/pet_stack/package.json
+++ b/PetAdoptions/cdk/pet_stack/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "^2.179.0-alpha.0",
-    "@aws-cdk/lambda-layer-kubectl-v32": "^2.0.3",
+    "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.3",
     "@types/js-yaml": "^4.0.9",
     "aws-cdk-lib": "^2.179.0",
     "cdk-ecr-deployment": "^3.1.9",


### PR DESCRIPTION
*Description of changes:*
- Downgrading EKS version to 1.31 to allow installation of ADOT addon to PetSite EKS cluster
- Downgrading kubectlLayer version to V31

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
