### PR TITLE
add IAM role, add-ons for Network Flow Monitor setup on EKS

### DIFF
--- a/PetAdoptions/cdk/pet_stack/resources/destroy_stack.sh
+++ b/PetAdoptions/cdk/pet_stack/resources/destroy_stack.sh
@@ -13,6 +13,14 @@ fi
 DDB_CONTRIB=$(aws ssm get-parameter --name '/petstore/dynamodbtablename' | jq .Parameter.Value -r)
 aws dynamodb update-contributor-insights --table-name $DDB_CONTRIB --contributor-insights-action DISABLE
 
+# Delete Network Flow Monitor
+if aws networkflowmonitor get-monitor --monitor-name network-flow-monitor-demo >/dev/null 2>&1; then
+    echo "Deleting network flow monitor..."
+    aws networkflowmonitor delete-monitor --monitor-name network-flow-monitor-demo
+else
+    echo "Network flow monitor not found, skipping delete."
+fi
+
 echo STARTING SERVICES CLEANUP
 echo -----------------------------
 


### PR DESCRIPTION
*Description of changes:*

**Adding**
- IAM Role
- eks-pod-identity-agent and
- aws-network-flow-monitoring-agent to EKS Cluster
- as part of Network Flow Monitor demo

Ref: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-NetworkFlowMonitor-agents-kubernetes-eks.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
