### PR TITLE
Removed hardcoded IAMrole name for Network Flow Monitor deployment

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -515,7 +515,6 @@ export class Services extends Stack {
 
         // IAM Role for Network Flow Monitor
         const networkFlowMonitorRole = new iam.CfnRole(this, 'NetworkFlowMonitorRole', {
-            roleName: 'network-flow-monitor-demo-role',
             assumeRolePolicyDocument: {
               Version: '2012-10-17',
               Statement: [


### PR DESCRIPTION
*Description of changes:*
Removed hardcoded IAMrole name for Network Flow Monitor deployment. This will allow CFN to create unique name for each deployment thus avoiding deployment failures when launching the demo in multiple regions with in the same account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
