### PR TITLE
Append region name to PetSite dashboard to avoid deployment failures

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -609,7 +609,7 @@ export class Services extends Stack {
         costControlDashboardBody = costControlDashboardBody.replaceAll("{{YOUR_LAMBDA_ARN}}", customWidgetFunction.functionArn);
 
         const petSiteCostControlDashboard = new cloudwatch.CfnDashboard(this, "PetSiteCostControlDashboard", {
-            dashboardName: "PetSite_Cost_Control_Dashboard",
+            dashboardName: "PetSite_Cost_Control_Dashboard_${region}",
             dashboardBody: costControlDashboardBody
         });
 


### PR DESCRIPTION
*Description of changes:*
- Appended region name to PetSite dashboard to avoid deployment failures in other regions within same account

