### PR TITLE
From Aurora serverless to Instance

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -1,0 +1,114 @@
+name: CDK Test
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'PetAdoptions/cdk/**'
+  push:
+    branches: [ main ]
+    paths:
+      - 'PetAdoptions/cdk/**'
+
+jobs:
+  cdk-synth-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: PetAdoptions/cdk/pet_stack/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: Build TypeScript
+        run: npm run build
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: Run CDK synth (dry run)
+        run: npx cdk synth --no-staging
+        working-directory: PetAdoptions/cdk/pet_stack
+        env:
+          # Set required AWS environment variables for synth
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          # CDK doesn't need real AWS credentials for synth, but some constructs might check
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+
+      - name: Run CDK diff (if applicable)
+        run: npx cdk diff --no-staging || true
+        working-directory: PetAdoptions/cdk/pet_stack
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
+
+  cdk-unit-tests:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: PetAdoptions/cdk/pet_stack/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: Build TypeScript
+        run: npm run build
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: Run unit tests
+        run: npm test
+        working-directory: PetAdoptions/cdk/pet_stack
+
+  cdk-lint-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: PetAdoptions/cdk/pet_stack/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: TypeScript compilation check
+        run: npx tsc --noEmit
+        working-directory: PetAdoptions/cdk/pet_stack
+
+      - name: CDK context validation
+        run: |
+          echo "Validating CDK context and configuration..."
+          npx cdk context --clear
+          npx cdk ls
+        working-directory: PetAdoptions/cdk/pet_stack
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ PetAdoptions/payforadoption-go/petadoptions
 **/.DS_Store
 **/assets
 **/.idea
+
+# editor settings
+.vscode/settings.json

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -130,8 +130,8 @@ export class Services extends Stack {
         }
 
         const auroraCluster = new rds.DatabaseCluster(this, 'Database', {
-            engine: rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_13_15 }),
-            parameterGroup: rds.ParameterGroup.fromParameterGroupName(this, 'ParameterGroup', 'default.aurora-postgresql13'),
+            engine: rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_16_6 }),
+            parameterGroup: rds.ParameterGroup.fromParameterGroupName(this, 'ParameterGroup', 'default.aurora-postgresql16'),
             vpc: theVPC,
             securityGroups: [rdssecuritygroup],
             defaultDatabaseName: 'adoptions',

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -137,13 +137,17 @@ export class Services extends Stack {
             defaultDatabaseName: 'adoptions',
             databaseInsightsMode: rds.DatabaseInsightsMode.ADVANCED,
             performanceInsightRetention: rds.PerformanceInsightRetention.MONTHS_15,
-            writer: rds.ClusterInstance.serverlessV2('writer', {
-                autoMinorVersionUpgrade: true
+            writer: rds.ClusterInstance.provisioned('writer', {
+                autoMinorVersionUpgrade: true,
+                instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MEDIUM),
             }),
+
             readers: [
+                rds.ClusterInstance.provisioned('reader1', {
+                    promotionTier: 1,
+                    instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MEDIUM),
+                }),
             ],
-            serverlessV2MaxCapacity: 1,
-            serverlessV2MinCapacity: 0.5,
         });
 
 

--- a/PetAdoptions/cdk/pet_stack/package.json
+++ b/PetAdoptions/cdk/pet_stack/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.4",
-    "aws-cdk": "^2.1000.2",
+    "aws-cdk": "^2.179.0",
     "cdk-nag": "^2.35.24",
     "constructs": "^10.4.2",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
*Description of changes:*
This PR:
- Switches CDK config to move to cluster instances
- Adds an aurora instance
- Bumps DB cluster to v16.6 from 13
- Bump CDK version to use 16.6
- add GH action to test cdk changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
