### PR TITLE
Migrate PetSearch from ADOT to CloudWatch agent

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -252,7 +252,7 @@ export class Services extends Stack {
             //repositoryURI: repositoryURI,
             healthCheck: '/health/status',
             desiredTaskCount: 2,
-            instrumentation: 'otel',
+            instrumentation: 'none',
             region: region,
             securityGroup: ecsServicesSecurityGroup
         })

--- a/PetAdoptions/cdk/pet_stack/lib/services/search-service.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services/search-service.ts
@@ -1,5 +1,6 @@
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as appsignals from '@aws-cdk/aws-applicationsignals-alpha';
 import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
 import { EcsService, EcsServiceProps } from './ecs-service'
 import { Construct } from 'constructs'
@@ -11,6 +12,21 @@ export class SearchService extends EcsService {
 
     this.taskDefinition.taskRole?.addManagedPolicy(iam.ManagedPolicy.fromManagedPolicyArn(this, 'AmazonDynamoDBReadOnlyAccess', 'arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess'));
     this.taskDefinition.taskRole?.addManagedPolicy(iam.ManagedPolicy.fromManagedPolicyArn(this, 'AmazonS3ReadOnlyAccess', 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'));
+
+    // Add Application Signals integration with CloudWatch agent
+    new appsignals.ApplicationSignalsIntegration(this, 'ApplicationSignalsIntegration', {
+      taskDefinition: this.taskDefinition,
+      instrumentation: {
+        sdkVersion: appsignals.JavaInstrumentationVersion.V2_10_0,
+      },
+      serviceName: 'PetSearch',
+      cloudWatchAgentSidecar: {
+        containerName: 'ecs-cwagent',
+        enableLogging: true,
+        cpu: 256,
+        memoryLimitMiB: 512,
+      }
+    });
   }
 
   containerImageFromRepository(repositoryURI: string) : ecs.ContainerImage {

--- a/PetAdoptions/cdk/pet_stack/package.json
+++ b/PetAdoptions/cdk/pet_stack/package.json
@@ -12,6 +12,7 @@
     "cdk": "cdk"
   },
   "dependencies": {
+    "@aws-cdk/aws-applicationsignals-alpha": "^2.204.0-alpha.0",
     "@aws-cdk/aws-lambda-python-alpha": "^2.204.0-alpha.0",
     "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.3",
     "@types/js-yaml": "^4.0.9",

--- a/PetAdoptions/petsearch-java/Dockerfile
+++ b/PetAdoptions/petsearch-java/Dockerfile
@@ -11,17 +11,7 @@ RUN gradle build -DexcludeTags='integration'
 FROM amazoncorretto:17-alpine
 WORKDIR /app
 
-ADD https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.21.1/aws-opentelemetry-agent.jar /app/aws-opentelemetry-agent.jar
-ENV JAVA_TOOL_OPTIONS "-javaagent:/app/aws-opentelemetry-agent.jar"
-
 ARG JAR_FILE=build/libs/\*.jar
 COPY --from=build /app/${JAR_FILE} ./app.jar
-
-# OpenTelemetry agent configuration
-ENV OTEL_TRACES_SAMPLER "always_on"
-ENV OTEL_PROPAGATORS "tracecontext,baggage,xray"
-ENV OTEL_RESOURCE_ATTRIBUTES "service.name=PetSearch"
-ENV OTEL_IMR_EXPORT_INTERVAL "10000"
-ENV OTEL_EXPORTER_OTLP_ENDPOINT "http://localhost:4317"
 
 ENTRYPOINT ["java","-jar","/app/app.jar"]


### PR DESCRIPTION
*Description of changes:*
Migrate PetSearch from ADOT to CW agent

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
