### PR TITLE
feat: add ecs env variables

### DIFF
--- a/src/cdk/lib/stages/applications.ts
+++ b/src/cdk/lib/stages/applications.ts
@@ -183,6 +183,9 @@ export class MicroservicesStack extends Stack {
                         cloudMapNamespace: cloudMap,
                         petFoodTable: dynamodbExports.petFoodsTable,
                         petFoodCartTable: dynamodbExports.petFoodsCartTable,
+                        additionalEnvironment: {
+                            ENABLE_JSON_LOGGING: 'true',
+                        },
                         assetsBucket: assetsBucket,
                         containerPort: 8080,
                         openSearchCollection: openSearchExports,


### PR DESCRIPTION
Provide the ability to add additional environment variables to an ECS Task definition. Added for Petfood but we can do for others as needed. Example definition in applications.ts. See 'additionalEnvironment'.

```
            if (name == MicroservicesNames.PetFood) {
                if (service?.hostType == HostType.ECS) {
                    svc = new PetFoodECSService(this, name, {
                        hostType: service.hostType,
                        computeType: service.computeType,
                        securityGroup: ecsExports.securityGroup,
                        ecsCluster: ecsExports.cluster,
                        disableService: service.disableService,
                        cpu: 1024,
                        memoryLimitMiB: 2048,
                        desiredTaskCount: 2,
                        name: name,
                        repositoryURI: `${baseURI}/${name}`,
                        healthCheck: '/health/status',
                        vpc: vpcExports,
                        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
                        createLoadBalancer: true,
                        cloudMapNamespace: cloudMap,
                        petFoodTable: dynamodbExports.petFoodsTable,
                        petFoodCartTable: dynamodbExports.petFoodsCartTable,
                        additionalEnvironment: {
                            ENABLE_JSON_LOGGING: 'true',
                        },
```