### PR TITLE
feat: add osis pipeline

### DIFF
--- a/src/cdk/bin/constants.ts
+++ b/src/cdk/bin/constants.ts
@@ -61,6 +61,11 @@ export const OPENSEARCH_COLLECTION_ENDPOINT_EXPORT_NAME = 'WorkshopOpenSearchCol
 export const OPENSEARCH_APPLICATION_ARN_EXPORT_NAME = 'WorkshopOpenSearchApplicationArn';
 export const OPENSEARCH_APPLICATION_ID_EXPORT_NAME = 'WorkshopOpenSearchApplicationId';
 
+// OpenSearch Ingestion Pipeline Export Names
+export const OPENSEARCH_PIPELINE_ARN_EXPORT_NAME = 'WorkshopOpenSearchPipelineArn';
+export const OPENSEARCH_PIPELINE_ENDPOINT_EXPORT_NAME = 'WorkshopOpenSearchPipelineEndpoint';
+export const OPENSEARCH_PIPELINE_ROLE_ARN_EXPORT_NAME = 'WorkshopOpenSearchPipelineRoleArn';
+
 // VPC Endpoint Export Names
 export const VPC_ENDPOINT_APIGATEWAY_ID_EXPORT_NAME = 'WorkshopVPCEndpointApiGatewayId';
 export const VPC_ENDPOINT_DYNAMODB_ID_EXPORT_NAME = 'WorkshopVPCEndpointDynamoDbId';

--- a/src/cdk/lib/constructs/opensearch-pipeline.ts
+++ b/src/cdk/lib/constructs/opensearch-pipeline.ts
@@ -1,0 +1,327 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CfnOutput, Fn, Stack } from 'aws-cdk-lib';
+import { CfnPipeline } from 'aws-cdk-lib/aws-osis';
+import { Role, ServicePrincipal, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+import {
+    OPENSEARCH_PIPELINE_ARN_EXPORT_NAME,
+    OPENSEARCH_PIPELINE_ENDPOINT_EXPORT_NAME,
+    OPENSEARCH_PIPELINE_ROLE_ARN_EXPORT_NAME,
+} from '../../bin/constants';
+import { Utilities } from '../utils/utilities';
+import { PARAMETER_STORE_PREFIX } from '../../bin/environment';
+import { OpenSearchCollection } from './opensearch-collection';
+
+/**
+ * Properties for configuring OpenSearchPipeline construct
+ * @interface OpenSearchPipelineProperties
+ */
+export interface OpenSearchPipelineProperties {
+    /**
+     * Name of the OpenSearch Ingestion pipeline
+     * @default 'pet-logs-pipeline'
+     */
+    pipelineName?: string;
+
+    /**
+     * OpenSearch collection to send logs to
+     */
+    openSearchCollection:
+        | OpenSearchCollection
+        | {
+              collectionArn: string;
+              collectionEndpoint: string;
+          };
+
+    /**
+     * Log buffer configuration
+     * @default { flushInterval: 60, batchSize: 1000 }
+     */
+    bufferOptions?: {
+        flushInterval?: number;
+        batchSize?: number;
+    };
+
+    /**
+     * Index template for log organization
+     * @default 'logs-{yyyy.MM.dd}'
+     */
+    indexTemplate?: string;
+
+    /**
+     * Minimum and maximum pipeline capacity units
+     * @default { min: 1, max: 4 }
+     */
+    capacityLimits?: {
+        min?: number;
+        max?: number;
+    };
+}
+
+/**
+ * AWS CDK Construct that creates OpenSearch Ingestion pipeline for log processing
+ * @class OpenSearchPipeline
+ * @extends Construct
+ */
+export class OpenSearchPipeline extends Construct {
+    /**
+     * The OpenSearch Ingestion pipeline for processing logs
+     * @public
+     */
+    public readonly pipeline: CfnPipeline;
+
+    /**
+     * The IAM role for the pipeline
+     * @public
+     */
+    public readonly pipelineRole: Role;
+
+    /**
+     * The pipeline endpoint URL
+     * @public
+     */
+    public readonly pipelineEndpoint: string;
+
+    /**
+     * Creates a new OpenSearchPipeline construct
+     * @param scope - The parent construct
+     * @param id - The construct ID
+     * @param properties - Configuration properties for the construct
+     */
+    constructor(scope: Construct, id: string, properties: OpenSearchPipelineProperties) {
+        super(scope, id);
+
+        // Validate required properties
+        if (!properties.openSearchCollection) {
+            throw new Error('OpenSearch collection is required for the pipeline');
+        }
+
+        // Set default values
+        const pipelineName = properties.pipelineName || 'pet-logs-pipeline';
+        const bufferOptions = {
+            flushInterval: properties.bufferOptions?.flushInterval || 60,
+            batchSize: properties.bufferOptions?.batchSize || 1000,
+        };
+        const indexTemplate = properties.indexTemplate || `${pipelineName}-logs`;
+        const capacityLimits = {
+            min: properties.capacityLimits?.min || 1,
+            max: properties.capacityLimits?.max || 4,
+        };
+
+        // Extract collection information
+        const collectionEndpoint =
+            'collectionEndpoint' in properties.openSearchCollection
+                ? properties.openSearchCollection.collectionEndpoint
+                : properties.openSearchCollection.collection.attrCollectionEndpoint;
+
+        const collectionArn =
+            'collectionArn' in properties.openSearchCollection
+                ? properties.openSearchCollection.collectionArn
+                : properties.openSearchCollection.collection.attrArn;
+
+        // Create IAM role for the pipeline
+        this.pipelineRole = new Role(this, 'PipelineRole', {
+            assumedBy: new ServicePrincipal('osis-pipelines.amazonaws.com'),
+            description: `IAM role for OpenSearch Ingestion pipeline ${pipelineName}`,
+        });
+
+        // Add permissions for OpenSearch Serverless access
+        this.pipelineRole.addToPolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: [
+                    'aoss:*', // Required for pipeline to connect to collection
+                ],
+                resources: [collectionArn, `${collectionArn}/*`],
+            }),
+        );
+
+        // Add CloudWatch logging permissions
+        this.pipelineRole.addToPolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ['logs:CreateLogStream', 'logs:PutLogEvents', 'logs:CreateLogGroup'],
+                resources: [
+                    `arn:aws:logs:${Stack.of(this).region}:${Stack.of(this).account}:log-group:/aws/vendedlogs/opensearch-ingestion/${pipelineName}*`,
+                ],
+            }),
+        );
+
+        // Add EventBridge permissions for pipeline lifecycle events
+        this.pipelineRole.addToPolicy(
+            new PolicyStatement({
+                effect: Effect.ALLOW,
+                actions: ['events:PutEvents', 'events:DescribeRule', 'events:ListTargetsByRule'],
+                resources: [
+                    `arn:aws:events:${Stack.of(this).region}:${Stack.of(this).account}:event-bus/default`,
+                    `arn:aws:events:${Stack.of(this).region}:${Stack.of(this).account}:rule/*`,
+                ],
+            }),
+        );
+
+        // Create CloudWatch log group for pipeline logs
+        // OpenSearch Ingestion requires log groups to use /aws/vendedlogs/ prefix
+        const logGroup = new LogGroup(this, 'PipelineLogGroup', {
+            logGroupName: `/aws/vendedlogs/opensearch-ingestion/${pipelineName}`,
+            retention: RetentionDays.ONE_WEEK,
+        });
+
+        // Generate pipeline configuration YAML
+        const pipelineConfiguration = this.generatePipelineConfiguration(
+            collectionEndpoint,
+            indexTemplate,
+            bufferOptions,
+            this.pipelineRole.roleArn,
+        );
+
+        // Create the OpenSearch Ingestion pipeline
+        this.pipeline = new CfnPipeline(this, 'Pipeline', {
+            pipelineName: pipelineName,
+            pipelineConfigurationBody: pipelineConfiguration,
+            minUnits: capacityLimits.min,
+            maxUnits: capacityLimits.max,
+            // Configure log publishing for pipeline monitoring
+            logPublishingOptions: {
+                isLoggingEnabled: true,
+                cloudWatchLogDestination: {
+                    logGroup: `/aws/vendedlogs/opensearch-ingestion/${pipelineName}`,
+                },
+            },
+            // Add tags for resource management
+            tags: [
+                {
+                    key: 'Name',
+                    value: pipelineName,
+                },
+                {
+                    key: 'Purpose',
+                    value: 'LogIngestion',
+                },
+                {
+                    key: 'Component',
+                    value: 'OpenSearchPipeline',
+                },
+            ],
+        });
+
+        // Add dependencies to ensure resources are created in correct order
+        this.pipeline.node.addDependency(this.pipelineRole);
+        this.pipeline.node.addDependency(logGroup);
+
+        // Set the pipeline endpoint (extract first endpoint from the array)
+        // The attrIngestEndpointUrls returns an array, so we need to get the first element
+        this.pipelineEndpoint = Fn.select(0, this.pipeline.attrIngestEndpointUrls);
+
+        this.createExports();
+        this.createOutputs();
+    }
+
+    /**
+     * Generates the pipeline configuration YAML for OpenSearch Ingestion
+     * Configures HTTP source, JSON parser processor, and OpenSearch Serverless sink
+     * @private
+     */
+    private generatePipelineConfiguration(
+        collectionEndpoint: string,
+        indexTemplate: string,
+        bufferOptions: { flushInterval: number; batchSize: number },
+        roleArn: string,
+    ): string {
+        // Strip https:// from collection endpoint for OpenSearch sink
+        const cleanEndpoint = collectionEndpoint.replace('https://', '');
+
+        // Generate YAML configuration for OSI pipeline with minimal processing
+        // FluentBit already sends JSON format, so we don't need to parse it
+        const yamlConfig = `version: "2"
+log-pipeline:
+  source:
+    http:
+      path: "/log/ingest"
+  processor:
+    - parse_json:
+        source: "log"
+        destination: "parsed_log"
+        parse_when: '/log != null and /log != ""'
+    - add_entries:
+        entries:
+          - key: "pipeline_version"
+            value: "1.0"
+  sink:
+    - opensearch:
+        hosts: ["${cleanEndpoint}"]
+        index: "${indexTemplate}"
+        aws:
+          region: "${Stack.of(this).region}"
+          sts_role_arn: "${roleArn}"
+          serverless: true`;
+
+        return yamlConfig;
+    }
+
+    /**
+     * Creates CloudFormation exports for the pipeline
+     * @private
+     */
+    private createExports(): void {
+        new CfnOutput(this, 'PipelineArn', {
+            value: this.pipeline.attrPipelineArn,
+            exportName: OPENSEARCH_PIPELINE_ARN_EXPORT_NAME,
+        });
+
+        new CfnOutput(this, 'PipelineEndpoint', {
+            value: this.pipelineEndpoint,
+            exportName: OPENSEARCH_PIPELINE_ENDPOINT_EXPORT_NAME,
+        });
+
+        new CfnOutput(this, 'PipelineRoleArn', {
+            value: this.pipelineRole.roleArn,
+            exportName: OPENSEARCH_PIPELINE_ROLE_ARN_EXPORT_NAME,
+        });
+    }
+
+    /**
+     * Imports pipeline information from CloudFormation exports
+     * @static
+     */
+    public static importFromExports(): {
+        pipelineArn: string;
+        pipelineEndpoint: string;
+        pipelineRoleArn: string;
+    } {
+        const pipelineArn = Fn.importValue(OPENSEARCH_PIPELINE_ARN_EXPORT_NAME);
+        const pipelineEndpoint = Fn.importValue(OPENSEARCH_PIPELINE_ENDPOINT_EXPORT_NAME);
+        const pipelineRoleArn = Fn.importValue(OPENSEARCH_PIPELINE_ROLE_ARN_EXPORT_NAME);
+
+        return {
+            pipelineArn,
+            pipelineEndpoint,
+            pipelineRoleArn,
+        };
+    }
+
+    /**
+     * Creates SSM parameter outputs for the pipeline
+     * @private
+     */
+    private createOutputs(): void {
+        if (this.pipeline) {
+            Utilities.createSsmParameters(
+                this,
+                PARAMETER_STORE_PREFIX,
+                new Map(
+                    Object.entries({
+                        opensearchpipelinearn: this.pipeline.attrPipelineArn,
+                        opensearchpipelineendpoint: this.pipelineEndpoint,
+                        opensearchpipelinerolearn: this.pipelineRole.roleArn,
+                    }),
+                ),
+            );
+        } else {
+            throw new Error('OpenSearch pipeline is not available');
+        }
+    }
+}

--- a/src/cdk/lib/stages/applications.ts
+++ b/src/cdk/lib/stages/applications.ts
@@ -184,7 +184,7 @@ export class MicroservicesStack extends Stack {
                         petFoodTable: dynamodbExports.petFoodsTable,
                         petFoodCartTable: dynamodbExports.petFoodsCartTable,
                         additionalEnvironment: {
-                            ENABLE_JSON_LOGGING: 'true',
+                            PETFOOD_ENABLE_JSON_LOGGING: 'true',
                             PETFOOD_OTLP_ENDPOINT: 'http://localhost:4317',
                             AWS_REGION: Stack.of(this).region,
                             PETFOOD_FOODS_TABLE_NAME: dynamodbExports.petFoodsTable.tableName,
@@ -193,7 +193,10 @@ export class MicroservicesStack extends Stack {
                         },
                         assetsBucket: assetsBucket,
                         containerPort: 8080,
-                        openSearchCollection: openSearchExports,
+                        // Use pipeline if available, otherwise fall back to direct collection access
+                        ...(ecsExports.openSearchPipeline
+                            ? { openSearchPipeline: ecsExports.openSearchPipeline }
+                            : { openSearchCollection: openSearchExports }),
                     });
                 } else {
                     throw new Error(`EKS is not supported for ${name}`);


### PR DESCRIPTION
Create an OpenSearch Ingestion pipeline. When an ECS service is passed an OpenSearch pipeline parameter it will create a fluentbit side car to forward the logs. This adds the capability to perform parsing and also will allow us in the future to collect other things like traces and metrics. Example
```
            if (name == MicroservicesNames.PetFood) {
                if (service?.hostType == HostType.ECS) {
                    svc = new PetFoodECSService(this, name, {
                        hostType: service.hostType,
                        computeType: service.computeType,
                        securityGroup: ecsExports.securityGroup,
                        ecsCluster: ecsExports.cluster,
                        disableService: service.disableService,
                        cpu: 1024,
                        memoryLimitMiB: 2048,
                        desiredTaskCount: 2,
                        name: name,
                        repositoryURI: `${baseURI}/${name}`,
                        healthCheck: '/health/status',
                        vpc: vpcExports,
                        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
                        createLoadBalancer: true,
                        cloudMapNamespace: cloudMap,
                        petFoodTable: dynamodbExports.petFoodsTable,
                        petFoodCartTable: dynamodbExports.petFoodsCartTable,
                        additionalEnvironment: {
                            PETFOOD_ENABLE_JSON_LOGGING: 'true',
                            PETFOOD_OTLP_ENDPOINT: 'http://localhost:4317',
                            AWS_REGION: Stack.of(this).region,
                            PETFOOD_FOODS_TABLE_NAME: dynamodbExports.petFoodsTable.tableName,
                            PETFOOD_CARTS_TABLE_NAME: dynamodbExports.petFoodsCartTable.tableName,
                            PETFOOD_ASSETS_BUCKET_NAME: assetsBucket.bucketName,
                        },
                        assetsBucket: assetsBucket,
                        containerPort: 8080,
                        // Use pipeline if available, otherwise fall back to direct collection access
                        ...(ecsExports.openSearchPipeline
                            ? { openSearchPipeline: ecsExports.openSearchPipeline }
                            : { openSearchCollection: openSearchExports }),
```
