### PR TITLE
feat: add AWS resource cleanup script for workshop environments

### DIFF
--- a/docs/CLEANUP_SCRIPT.md
+++ b/docs/CLEANUP_SCRIPT.md
@@ -1,0 +1,375 @@
+# AWS Resource Cleanup Script for One Observability Workshop
+
+This script identifies and safely deletes AWS resources that may remain after CloudFormation stacks are destroyed. It targets resources tagged with specific workshop tags and provides multiple safety mechanisms to prevent accidental deletions.
+
+## 🚨 Important Safety Notice
+
+**This script performs destructive operations that cannot be undone!**
+
+- Always run with `--dry-run` first to see what would be deleted
+- Only run against resources you own and are certain you want to delete
+- Ensure you have proper AWS credentials and permissions
+- Test in a non-production environment first
+- Keep backups of any important data before running
+
+## 📋 Prerequisites
+
+1. **Node.js and npm** installed
+2. **AWS CLI configured** with appropriate credentials
+3. **AWS permissions** for the following services:
+   - CloudWatch Logs (logs:DescribeLogGroups, logs:DeleteLogGroup)
+   - EC2 (ec2:DescribeVolumes, ec2:DeleteVolume, ec2:DescribeSnapshots, ec2:DeleteSnapshot)
+   - RDS (rds:DescribeDB*Snapshots, rds:DeleteDB*Snapshot)
+   - ECS (ecs:ListTaskDefinitions, ecs:DescribeTaskDefinition, ecs:DeregisterTaskDefinition)
+   - S3 (s3:ListBuckets, s3:GetBucketTagging, s3:ListObjectVersions, s3:DeleteObject, s3:DeleteBucket)
+   - Resource Groups Tagging API (resourcegroupstaggingapi:GetResources)
+
+## 🏷️ Resource Identification
+
+The script identifies workshop resources using these tags:
+```javascript
+{
+  environment: 'non-prod',
+  application: 'One Observability Workshop',
+  stackName: '<your-stack-name>'
+}
+```
+
+## 🧹 Resources Cleaned Up
+
+| Resource Type | Description | Special Handling |
+|---------------|-------------|------------------|
+| **CloudWatch Log Groups** | Log groups with workshop tags | Pattern matching for untagged groups |
+| **EBS Volumes** | Unattached volumes only | Attached volumes are skipped for safety |
+| **EBS Snapshots** | User-owned snapshots | Only your account's snapshots |
+| **RDS Backups** | Manual DB and cluster snapshots | Automatic backups are not touched |
+| **ECS Task Definitions** | Active task definitions | Deregistered, not deleted |
+| **S3 Buckets** | Workshop-tagged buckets | **All objects and versions deleted first** |
+
+## 🚀 Installation and Setup
+
+1. Navigate to the CDK directory:
+```bash
+cd src/cdk
+```
+
+2. Install dependencies (if not already done):
+```bash
+npm install
+```
+
+3. Verify the script is available:
+```bash
+npm run cleanup -- --help
+```
+
+## 📖 Usage
+
+### Basic Usage Patterns
+
+```bash
+# 1. Discover all workshop stack names
+npm run cleanup -- --discover
+
+# 2. Preview what would be deleted (RECOMMENDED FIRST STEP)
+npm run cleanup -- --stack-name MyWorkshopStack --dry-run
+
+# 3. Actually perform the cleanup
+npm run cleanup -- --stack-name MyWorkshopStack
+
+# 4. Clean up in a specific region
+npm run cleanup -- --stack-name MyWorkshopStack --region us-west-2
+```
+
+### Command Line Options
+
+| Option | Description | Required | Example |
+|--------|-------------|----------|---------|
+| `--stack-name <name>` | Specific stack name to clean up | Yes* | `--stack-name MyWorkshopStack` |
+| `--discover` | List all found stack names | No | `--discover` |
+| `--dry-run` | Preview without deleting | No | `--dry-run` |
+| `--region <region>` | AWS region | No | `--region us-west-2` |
+| `--cleanup-missing-tags` | Clean up resources without stackName tags | No | `--cleanup-missing-tags` |
+| `--skip-confirmation` | Skip confirmation prompts | No | `--skip-confirmation` |
+| `--help` | Show help message | No | `--help` |
+
+*Required unless using `--discover` or `--cleanup-missing-tags`
+
+## 🔍 Discovery Mode
+
+Use discovery mode to find all workshop stack names in your AWS account:
+
+```bash
+npm run cleanup -- --discover
+```
+
+**Example output:**
+```
+🔍 Discovering stack names from existing resources...
+
+Found the following workshop stack names:
+   • MyWorkshopStack-2024-01
+   • TestWorkshopStack
+   • DemoWorkshopStack-v2
+
+To clean up a specific stack, run:
+npm run cleanup -- --stack-name <STACK_NAME> --dry-run
+```
+
+## 🧪 Dry Run Mode (Highly Recommended)
+
+**Always run in dry-run mode first** to see what would be deleted:
+
+```bash
+npm run cleanup -- --stack-name MyWorkshopStack --dry-run
+```
+
+**Example output:**
+```
+🧹 [DRY RUN] Cleaning up resources for stack: MyWorkshopStack
+
+🗂️  Cleaning up CloudWatch Log Groups...
+   [DRY RUN] Would delete log group: /aws/lambda/MyWorkshopStack-function
+
+💾 Cleaning up EBS Volumes...
+   [DRY RUN] Would delete EBS volume: vol-1234567890abcdef0
+
+🪣 Cleaning up S3 Buckets...
+   [DRY RUN] Would empty and delete S3 bucket: myworkshopstack-artifacts-bucket
+
+📊 [DRY RUN] Cleanup Summary:
+   CloudWatch Log Groups: 1
+   EBS Volumes: 1
+   S3 Buckets: 1
+   Total Resources: 3
+
+⚠️  This was a dry run. To actually delete these resources, run without --dry-run
+```
+
+## 🏷️ Handling Resources with Missing Tags
+
+### Problem
+Older workshop deployments may lack the `stackName` tag, making them impossible to identify by stack name alone.
+
+### Detection and Cleanup
+```bash
+# Check for resources with missing stackName tags
+npm run cleanup -- --cleanup-missing-tags --dry-run
+
+# Actually clean up resources without stackName tags
+npm run cleanup -- --cleanup-missing-tags
+```
+
+The script uses a fallback approach:
+1. **First**: Resources with `environment` + `application` tags (but missing valid `stackName`)
+2. **Fallback**: Resources with only `application` tag (broader scope)
+
+## 💡 Workflow Examples
+
+### Standard Workshop Cleanup
+```bash
+# Step 1: Discover stacks
+npm run cleanup -- --discover
+
+# Step 2: Preview cleanup for your stack
+npm run cleanup -- --stack-name MyWorkshopStack-2024-01 --dry-run
+
+# Step 3: Review the output carefully
+
+# Step 4: Perform actual cleanup
+npm run cleanup -- --stack-name MyWorkshopStack-2024-01
+```
+
+### Multi-Region Cleanup
+```bash
+# Clean up in multiple regions
+npm run cleanup -- --stack-name MyWorkshopStack --region us-east-1 --dry-run
+npm run cleanup -- --stack-name MyWorkshopStack --region us-west-2 --dry-run
+
+# If resources found, clean them up
+npm run cleanup -- --stack-name MyWorkshopStack --region us-east-1
+npm run cleanup -- --stack-name MyWorkshopStack --region us-west-2
+```
+
+## 🛡️ Safety Features
+
+### Built-in Safety Mechanisms
+- **EBS Volumes**: Only deletes unattached volumes
+- **RDS Backups**: Only touches manual snapshots, not automated backups
+- **S3 Buckets**: Handles versioned objects and delete markers properly
+- **Error Handling**: Continues processing other resources if one fails
+- **Tag Verification**: Double-checks tags before deletion
+- **Dry-run Mode**: Safe preview of all operations
+- **User Confirmation**: Prompts for confirmation before destructive operations
+
+### What the Script Will NOT Delete
+- Attached EBS volumes
+- Automated RDS backups
+- Resources without proper workshop tags
+- Resources from other AWS accounts
+- Resources in use by running applications
+
+## 📊 Understanding Output
+
+### Success Messages
+- `✅ Deleted <resource-type>: <resource-id>` - Resource successfully deleted
+- `🗂️ Emptying S3 bucket: <bucket-name>` - S3 bucket being emptied
+- `Deleted X objects` - Objects removed from S3 bucket
+
+### Error Messages
+- `❌ Failed to delete <resource>: <error>` - Specific resource deletion failed
+- `❌ Error cleaning up <service>: <error>` - Service-level error occurred
+
+### Summary Report
+```
+📊 Cleanup Summary:
+   CloudWatch Log Groups: 2
+   EBS Volumes: 1
+   EBS Snapshots: 0
+   RDS Backups: 0
+   ECS Task Definitions: 3
+   S3 Buckets: 1
+   Total Resources: 7
+
+✅ Successfully cleaned up 7 resources!
+```
+
+## 🔧 Troubleshooting
+
+### Common Issues and Solutions
+
+#### Permission Denied Errors
+**Problem**: `AccessDenied` or `UnauthorizedOperation` errors
+**Solution**:
+- Verify AWS credentials: `aws sts get-caller-identity`
+- Check IAM permissions for required services
+- Ensure you have permission to delete specific resource types
+
+#### Resource Not Found
+**Problem**: Resources show in dry-run but fail during deletion
+**Solution**:
+- Resource may have been deleted by another process
+- Check if resource still exists in AWS console
+- Re-run discovery to see current state
+
+#### S3 Bucket Deletion Fails
+**Problem**: Bucket deletion fails with `BucketNotEmpty`
+**Solution**:
+- Script should handle this automatically
+- Manually check bucket in console for remaining objects
+- Verify bucket versioning and delete markers
+
+### Debug Steps
+
+1. **Verify AWS Configuration**:
+   ```bash
+   aws sts get-caller-identity
+   aws configure list
+   ```
+
+2. **Check Resource Existence**:
+   ```bash
+   # List resources manually
+   aws ec2 describe-volumes --filters Name=tag:stackName,Values=MyWorkshopStack
+   aws logs describe-log-groups
+   aws s3 ls
+   ```
+
+3. **Test Permissions**:
+   ```bash
+   # Test basic permissions
+   aws ec2 describe-volumes
+   aws s3 list-buckets
+   aws logs describe-log-groups
+   ```
+
+## 🏗️ Technical Details
+
+### Architecture
+- **Language**: TypeScript with Node.js
+- **AWS SDK**: AWS SDK v3 for JavaScript
+- **Execution**: Uses ts-node for direct TypeScript execution
+- **Parallelization**: Cleans up different resource types in parallel
+- **Error Handling**: Graceful degradation with detailed error reporting
+
+### S3 Bucket Special Handling
+S3 buckets cannot be deleted if they contain objects. The script automatically:
+1. Lists all object versions (including delete markers)
+2. Deletes objects in batches of 1000
+3. Handles versioned objects and delete markers
+4. Processes all pages until bucket is completely empty
+5. Only then attempts bucket deletion
+
+## 🔐 Security Considerations
+
+### Required IAM Permissions
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:DescribeLogGroups",
+                "logs:DeleteLogGroup",
+                "ec2:DescribeVolumes",
+                "ec2:DeleteVolume",
+                "ec2:DescribeSnapshots",
+                "ec2:DeleteSnapshot",
+                "rds:DescribeDBSnapshots",
+                "rds:DeleteDBSnapshot",
+                "rds:DescribeDBClusterSnapshots",
+                "rds:DeleteDBClusterSnapshot",
+                "ecs:ListTaskDefinitions",
+                "ecs:DescribeTaskDefinition",
+                "ecs:DeregisterTaskDefinition",
+                "s3:ListBucket",
+                "s3:GetBucketTagging",
+                "s3:ListObjectVersions",
+                "s3:DeleteObject",
+                "s3:DeleteBucket",
+                "resource-groups:GetResources"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### Security Features
+- **Tag-based filtering**: Only affects resources with workshop tags
+- **Dry-run default**: Encourages preview before deletion
+- **Confirmation prompts**: Prevents accidental deletions
+- **Scope limitations**: Focuses on specific resource types only
+- **Audit trail**: All operations logged to CloudTrail
+
+## 🤝 Integration with CDK
+
+### Typical Cleanup Workflow
+```bash
+# Primary cleanup
+cdk destroy --all
+
+# Find remaining resources
+npm run cleanup -- --discover
+
+# Clean specific leftovers
+npm run cleanup -- --stack-name MyStack --dry-run
+npm run cleanup -- --stack-name MyStack
+```
+
+### When to Use
+- **After stack deletion**: When `cdk destroy` leaves resources behind
+- **Bulk cleanup**: Cleaning up multiple old workshop instances
+- **Edge case handling**: Resources with missing or incorrect tags
+- **Cost management**: Removing forgotten resources that incur charges
+
+## 📚 Related Documentation
+
+- [AWS Resource Groups Tagging API](https://docs.aws.amazon.com/resourcegroupstaggingapi/)
+- [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/)
+- [One Observability Workshop](../README.md)
+
+---
+
+**Remember**: This is a destructive operation. Always test with `--dry-run` first and ensure you have backups of any important data.

--- a/src/cdk/package-lock.json
+++ b/src/cdk/package-lock.json
@@ -11,6 +11,12 @@
                 "@aws-cdk/aws-applicationsignals-alpha": "^2.214.0-alpha.0",
                 "@aws-cdk/aws-lambda-python-alpha": "2.214.0-alpha.0",
                 "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
+                "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
+                "@aws-sdk/client-ec2": "^3.0.0",
+                "@aws-sdk/client-ecs": "^3.0.0",
+                "@aws-sdk/client-rds": "^3.0.0",
+                "@aws-sdk/client-resource-groups-tagging-api": "^3.0.0",
+                "@aws-sdk/client-s3": "^3.0.0",
                 "@types/yaml": "^1.9.7",
                 "aws-cdk": "^2.1029.0",
                 "aws-cdk-lib": "2.214.0",
@@ -126,6 +132,1242 @@
             "peerDependencies": {
                 "aws-cdk-lib": "^2.94.0",
                 "constructs": "^10.0.5"
+            }
+        },
+        "node_modules/@aws-crypto/crc32": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/crc32c": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+            "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+            "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch-logs": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.886.0.tgz",
+            "integrity": "sha512-CNk3RPl+02p1ww22nfrv1VoyakoV/OjF2q1/wkVfXRPD1oD7UkTvSUd4zuvP/cXPyaAfg6QIYvOLFWKZ2Hkp1w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/eventstream-serde-browser": "^4.0.5",
+                "@smithy/eventstream-serde-config-resolver": "^4.1.3",
+                "@smithy/eventstream-serde-node": "^4.0.5",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch-logs/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-ec2": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.886.0.tgz",
+            "integrity": "sha512-MKjZzs2ockhasC45m/G75kjRdrGu/B7A45fVdxB/uKLBDlym7gbgpH86YpIMUmg/MsaVpgnb+33K+48MtQz0RA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-sdk-ec2": "3.882.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-waiter": "^4.0.7",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ec2/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-ecs": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.886.0.tgz",
+            "integrity": "sha512-22bqXAXAdVIXbIbRaSTyhYkrP0LBLFkvnP6wr2k4um5iHCKWbpl8tEGIUVmk80itXpsR/ASzZbt+YKkp9MDn5Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-waiter": "^4.0.7",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-ecs/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-rds": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.886.0.tgz",
+            "integrity": "sha512-RDnriU4vpcoLQKIZHUcT0OcmYG8w2KZLmHRGiFHLU7t9W+8c8vNWheycD4bKhW1N3gEeRU5JNk8uqRUUFAixew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-sdk-rds": "3.882.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-waiter": "^4.0.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-resource-groups-tagging-api": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api/-/client-resource-groups-tagging-api-3.886.0.tgz",
+            "integrity": "sha512-FACt4t+Az4FpKLbbcFpW1FYw0+896j7nDvXCMbEA5WpKhzuVJ5B9GvnBLtEgv9nJqsBsORIuc8dGfzPGI17Kpw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.886.0.tgz",
+            "integrity": "sha512-IuZ2EHiSMkEqjOJk/QMQG55zGpj/iDkKNS1V3oKV6ClstmErySBfW0Ri8GuW7WJ1k1pkFO+hvgL6yn1yO+Y6XQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "5.2.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-node": "3.886.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.873.0",
+                "@aws-sdk/middleware-expect-continue": "3.873.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.883.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-location-constraint": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-sdk-s3": "3.883.0",
+                "@aws-sdk/middleware-ssec": "3.873.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/signature-v4-multi-region": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@aws-sdk/xml-builder": "3.873.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/eventstream-serde-browser": "^4.0.5",
+                "@smithy/eventstream-serde-config-resolver": "^4.1.3",
+                "@smithy/eventstream-serde-node": "^4.0.5",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-blob-browser": "^4.0.5",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/hash-stream-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/md5-js": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-stream": "^4.2.4",
+                "@smithy/util-utf8": "^4.0.0",
+                "@smithy/util-waiter": "^4.0.7",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.886.0.tgz",
+            "integrity": "sha512-CwpPZBlONsUO6OvMzNNP9PETZ3dPCQum3nUisk5VuzLTvNd80w2aWeSN/TpcAAbNvcRYbM+FsC4gBm4Q4VWn0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.883.0.tgz",
+            "integrity": "sha512-FmkqnqBLkXi4YsBPbF6vzPa0m4XKUuvgKDbamfw4DZX2CzfBZH6UU4IwmjNV3ZM38m0xraHarK8KIbGSadN3wg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/xml-builder": "3.873.0",
+                "@smithy/core": "^3.9.2",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/signature-v4": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-utf8": "^4.0.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.883.0.tgz",
+            "integrity": "sha512-Z6tPBXPCodfhIF1rvQKoeRGMkwL6TK0xdl1UoMIA1x4AfBpPICAF77JkFBExk/pdiFYq1d04Qzddd/IiujSlLg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.883.0.tgz",
+            "integrity": "sha512-P589ug1lMOOEYLTaQJjSP+Gee34za8Kk2LfteNQfO9SpByHFgGj++Sg8VyIe30eZL8Q+i4qTt24WDCz1c+dgYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-stream": "^4.2.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.886.0.tgz",
+            "integrity": "sha512-86ZuuUGLzzYqxkglFBUMCsvb7vSr+IeIPkXD/ERuX9wX0xPxBK961UG7pygO7yaAVzcHSWbWArAXOcEWVlk+7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/credential-provider-env": "3.883.0",
+                "@aws-sdk/credential-provider-http": "3.883.0",
+                "@aws-sdk/credential-provider-process": "3.883.0",
+                "@aws-sdk/credential-provider-sso": "3.886.0",
+                "@aws-sdk/credential-provider-web-identity": "3.886.0",
+                "@aws-sdk/nested-clients": "3.886.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/credential-provider-imds": "^4.0.7",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/shared-ini-file-loader": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.886.0.tgz",
+            "integrity": "sha512-hyXQrUW6bXkSWOZlNWnNcbXsjM0CBIOfutDFd3tS7Ilhqkx8P3eptT0fVR8GFxNg/ruq5PvnybGK83brUmD7tw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.883.0",
+                "@aws-sdk/credential-provider-http": "3.883.0",
+                "@aws-sdk/credential-provider-ini": "3.886.0",
+                "@aws-sdk/credential-provider-process": "3.883.0",
+                "@aws-sdk/credential-provider-sso": "3.886.0",
+                "@aws-sdk/credential-provider-web-identity": "3.886.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/credential-provider-imds": "^4.0.7",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/shared-ini-file-loader": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.883.0.tgz",
+            "integrity": "sha512-m1shbHY/Vppy4EdddG9r8x64TO/9FsCjokp5HbKcZvVoTOTgUJrdT8q2TAQJ89+zYIJDqsKbqfrmfwJ1zOdnGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/shared-ini-file-loader": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.886.0.tgz",
+            "integrity": "sha512-KxNgGcT/2ec7XBhiYGBYlk+UyiMqosi5LzLjq2qR4nYf8Deo/lCtbqXSQplwSQ0JIV2kNDcnMQiSafSS9TrL/A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.886.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/token-providers": "3.886.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/shared-ini-file-loader": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.886.0.tgz",
+            "integrity": "sha512-pilcy1GUOr4lIWApTcgJLGL+t79SOoe66pzmranQhbn+HGAp2VgiZizeID9P3HLmZObStVal4yTaJur0hWb5ZQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/nested-clients": "3.886.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.873.0.tgz",
+            "integrity": "sha512-b4bvr0QdADeTUs+lPc9Z48kXzbKHXQKgTvxx/jXDgSW9tv4KmYPO1gIj6Z9dcrBkRWQuUtSW3Tu2S5n6pe+zeg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-arn-parser": "3.873.0",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-config-provider": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.873.0.tgz",
+            "integrity": "sha512-GIqoc8WgRcf/opBOZXFLmplJQKwOMjiOMmDz9gQkaJ8FiVJoAp8EGVmK2TOWZMQUYsavvHYsHaor5R2xwPoGVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.883.0.tgz",
+            "integrity": "sha512-EloU4ZjkH+CXCHJcYElXo5nZ1vK6Miam/S02YSHk5JTrJkm4RV478KXXO29TIIAwZXcLT/FEQOZ9ZH/JHFFCFQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/crc32": "5.2.0",
+                "@aws-crypto/crc32c": "5.2.0",
+                "@aws-crypto/util": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-stream": "^4.2.4",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+            "integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.873.0.tgz",
+            "integrity": "sha512-r+hIaORsW/8rq6wieDordXnA/eAu7xAPLue2InhoEX6ML7irP52BgiibHLpt9R0psiCzIHhju8qqKa4pJOrmiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.876.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.876.0.tgz",
+            "integrity": "sha512-cpWJhOuMSyz9oV25Z/CMHCBTgafDCbv7fHR80nlRrPdPZ8ETNsahwRgltXP1QJJ8r3X/c1kwpOR7tc+RabVzNA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.886.0.tgz",
+            "integrity": "sha512-yMMlPqiX1SXFwQ0L1a/U19rdXx7eYseHsJEC9F9M5LUUPBI7k117nA0vXxvsvODVQ6JKtY7nTiPrc98GcVKgnw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@aws/lambda-invoke-store": "^0.0.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-ec2": {
+            "version": "3.882.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.882.0.tgz",
+            "integrity": "sha512-8oaMNXj6VnDsN2eczx3RC/NDm/uf/Vt0EKEkvF6WSZlc1nqFhvVj0UiCS08VIZpeRNNc9IBselbCTI/4vQ9M4Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-format-url": "3.873.0",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/signature-v4": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-rds": {
+            "version": "3.882.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.882.0.tgz",
+            "integrity": "sha512-tlSNhScz/5BmBRrv9ocYc4BEdQzArGmPkJ2uFmXB68p2lI1W1XmgNTnfgHCwRl2RIGqbhp8gQ0+GklAI89CK8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-format-url": "3.873.0",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/signature-v4": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.883.0.tgz",
+            "integrity": "sha512-i4sGOj9xhSN6/LkYj3AJ2SRWENnpN9JySwNqIoRqO1Uon8gfyNLJd1yV+s43vXQsU5wbKWVXK8l9SRo+vNTQwg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-arn-parser": "3.873.0",
+                "@smithy/core": "^3.9.2",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/signature-v4": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-stream": "^4.2.4",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.873.0.tgz",
+            "integrity": "sha512-AF55J94BoiuzN7g3hahy0dXTVZahVi8XxRBLgzNp6yQf0KTng+hb/V9UQZVYY1GZaDczvvvnqC54RGe9OZZ9zQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.883.0.tgz",
+            "integrity": "sha512-q58uLYnGLg7hsnWpdj7Cd1Ulsq1/PUJOHvAfgcBuiDE/+Fwh0DZxZZyjrU+Cr+dbeowIdUaOO8BEDDJ0CUenJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@smithy/core": "^3.9.2",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.886.0.tgz",
+            "integrity": "sha512-CqeRdkNyJ7LlKLQtMTzK11WIiryEK8JbSL5LCia0B1Lp22OByDUiUSFZZ3FZq9poD5qHQI63pHkzAr5WkLGS5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/middleware-host-header": "3.873.0",
+                "@aws-sdk/middleware-logger": "3.876.0",
+                "@aws-sdk/middleware-recursion-detection": "3.886.0",
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/region-config-resolver": "3.873.0",
+                "@aws-sdk/types": "3.862.0",
+                "@aws-sdk/util-endpoints": "3.879.0",
+                "@aws-sdk/util-user-agent-browser": "3.873.0",
+                "@aws-sdk/util-user-agent-node": "3.883.0",
+                "@smithy/config-resolver": "^4.1.5",
+                "@smithy/core": "^3.9.2",
+                "@smithy/fetch-http-handler": "^5.1.1",
+                "@smithy/hash-node": "^4.0.5",
+                "@smithy/invalid-dependency": "^4.0.5",
+                "@smithy/middleware-content-length": "^4.0.5",
+                "@smithy/middleware-endpoint": "^4.1.21",
+                "@smithy/middleware-retry": "^4.1.22",
+                "@smithy/middleware-serde": "^4.0.9",
+                "@smithy/middleware-stack": "^4.0.5",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/node-http-handler": "^4.1.1",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/smithy-client": "^4.5.2",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.29",
+                "@smithy/util-defaults-mode-node": "^4.0.29",
+                "@smithy/util-endpoints": "^3.0.7",
+                "@smithy/util-middleware": "^4.0.5",
+                "@smithy/util-retry": "^4.0.7",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+            "integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/types": "^4.3.2",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.883.0.tgz",
+            "integrity": "sha512-86PO7+xhuQ48cD3xlZgEpRxVP1lBarWAJy23sB6zZLHgZSbnYXYjRFuyxX4PlFzqllM3PDKJvq3WnXeqSXeNsg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/protocol-http": "^5.1.3",
+                "@smithy/signature-v4": "^5.1.3",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.886.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.886.0.tgz",
+            "integrity": "sha512-dYS3apmGcldFglpAiAajcdDKtKjBw/NkG6nRYIC2q7+OZsxeyzunT1EUSxV4xphLoqiuhuCg/fTnBI3WVtb3IQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.883.0",
+                "@aws-sdk/nested-clients": "3.886.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/property-provider": "^4.0.5",
+                "@smithy/shared-ini-file-loader": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.862.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
+            "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
+            "integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.879.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.879.0.tgz",
+            "integrity": "sha512-aVAJwGecYoEmbEFju3127TyJDF9qJsKDUUTRMDuS8tGn+QiWQFnfInmbt+el9GU1gEJupNTXV+E3e74y51fb7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/types": "^4.3.2",
+                "@smithy/url-parser": "^4.0.5",
+                "@smithy/util-endpoints": "^3.0.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+            "integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/querystring-builder": "^4.0.5",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.873.0.tgz",
+            "integrity": "sha512-xcVhZF6svjM5Rj89T1WzkjQmrTF6dpR2UvIHPMTnSZoNe6CixejPZ6f0JJ2kAhO8H+dUHwNBlsUgOTIKiK/Syg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+            "integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/types": "^4.3.2",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.883.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.883.0.tgz",
+            "integrity": "sha512-28cQZqC+wsKUHGpTBr+afoIdjS6IoEJkMqcZsmo2Ag8LzmTa6BUWQenFYB0/9BmDy4PZFPUn+uX+rJgWKB+jzA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.883.0",
+                "@aws-sdk/types": "3.862.0",
+                "@smithy/node-config-provider": "^4.1.4",
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.873.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+            "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.3.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+            "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1550,6 +2792,754 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
+        "node_modules/@smithy/abort-controller": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
+            "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/chunked-blob-reader": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.1.0.tgz",
+            "integrity": "sha512-a36AtR7Q7XOhRPt6F/7HENmTWcB8kN7mDJcOFM/+FuKO6x88w8MQJfYCufMWh4fGyVkPjUh3Rrz/dnqFQdo6OQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/chunked-blob-reader-native": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.1.0.tgz",
+            "integrity": "sha512-Bnv0B3nSlfB2mPO0WgM49I/prl7+kamF042rrf3ezJ3Z4C7csPYvyYgZfXTGXwXfj1mAwDWjE/ybIf49PzFzvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-base64": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.1.tgz",
+            "integrity": "sha512-FXil8q4QN7mgKwU2hCLm0ltab8NyY/1RiqEf25Jnf6WLS3wmb11zGAoLETqg1nur2Aoibun4w4MjeN9CMJ4G6A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-config-provider": "^4.1.0",
+                "@smithy/util-middleware": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.11.0.tgz",
+            "integrity": "sha512-Abs5rdP1o8/OINtE49wwNeWuynCu0kme1r4RI3VXVrHr4odVDG7h7mTnw1WXXfN5Il+c25QOnrdL2y56USfxkA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.1.1",
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-base64": "^4.1.0",
+                "@smithy/util-body-length-browser": "^4.1.0",
+                "@smithy/util-middleware": "^4.1.1",
+                "@smithy/util-stream": "^4.3.1",
+                "@smithy/util-utf8": "^4.1.0",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.1.tgz",
+            "integrity": "sha512-1WdBfM9DwA59pnpIizxnUvBf/de18p4GP+6zP2AqrlFzoW3ERpZaT4QueBR0nS9deDMaQRkBlngpVlnkuuTisQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/property-provider": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/url-parser": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-codec": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.1.1.tgz",
+            "integrity": "sha512-PwkQw1hZwHTQB6X5hSUWz2OSeuj5Z6enWuAqke7DgWoP3t6vg3ktPpqPz3Erkn6w+tmsl8Oss6nrgyezoea2Iw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-hex-encoding": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-browser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.1.1.tgz",
+            "integrity": "sha512-Q9QWdAzRaIuVkefupRPRFAasaG/droBqn1feiMnmLa+LLEUG45pqX1+FurHFmlqiCfobB3nUlgoJfeXZsr7MPA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/eventstream-serde-universal": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-config-resolver": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.2.1.tgz",
+            "integrity": "sha512-oSUkF9zDN9zcOUBMtxp8RewJlh71E9NoHWU8jE3hU9JMYCsmW4assVTpgic/iS3/dM317j6hO5x18cc3XrfvEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-node": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.1.1.tgz",
+            "integrity": "sha512-tn6vulwf/ScY0vjhzptSJuDJJqlhNtUjkxJ4wiv9E3SPoEqTEKbaq6bfqRO7nvhTG29ALICRcvfFheOUPl8KNA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/eventstream-serde-universal": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/eventstream-serde-universal": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.1.1.tgz",
+            "integrity": "sha512-uLOAiM/Dmgh2CbEXQx+6/ssK7fbzFhd+LjdyFxXid5ZBCbLHTFHLdD/QbXw5aEDsLxQhgzDxLLsZhsftAYwHJA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/eventstream-codec": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
+            "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/querystring-builder": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-base64": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-blob-browser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.1.1.tgz",
+            "integrity": "sha512-avAtk++s1e/1VODf+rg7c9R2pB5G9y8yaJaGY4lPZI2+UIqVyuSDMikWjeWfBVmFZ3O7NpDxBbUCyGhThVUKWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/chunked-blob-reader": "^5.1.0",
+                "@smithy/chunked-blob-reader-native": "^4.1.0",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
+            "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-buffer-from": "^4.1.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-stream-node": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.1.1.tgz",
+            "integrity": "sha512-3ztT4pV0Moazs3JAYFdfKk11kYFDo4b/3R3+xVjIm6wY9YpJf+xfz+ocEnNKcWAdcmSMqi168i2EMaKmJHbJMA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
+            "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
+            "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/md5-js": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.1.tgz",
+            "integrity": "sha512-MvWXKK743BuHjr/hnWuT6uStdKEaoqxHAQUvbKJPPZM5ZojTNFI5D+47BoQfBE5RgGlRRty05EbWA+NXDv+hIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
+            "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.1.tgz",
+            "integrity": "sha512-fUTMmQvQQZakXOuKizfu7fBLDpwvWZjfH6zUK2OLsoNZRZGbNUdNSdLJHpwk1vS208jtDjpUIskh+JoA8zMzZg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.11.0",
+                "@smithy/middleware-serde": "^4.1.1",
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/shared-ini-file-loader": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/url-parser": "^4.1.1",
+                "@smithy/util-middleware": "^4.1.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.2.1.tgz",
+            "integrity": "sha512-JzfvjwSJXWRl7LkLgIRTUTd2Wj639yr3sQGpViGNEOjtb0AkAuYqRAHs+jSOI/LPC0ZTjmFVVtfrCICMuebexw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/service-error-classification": "^4.1.1",
+                "@smithy/smithy-client": "^4.6.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-middleware": "^4.1.1",
+                "@smithy/util-retry": "^4.1.1",
+                "@types/uuid": "^9.0.1",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
+            "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
+            "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.1.tgz",
+            "integrity": "sha512-AIA0BJZq2h295J5NeCTKhg1WwtdTA/GqBCaVjk30bDgMHwniUETyh5cP9IiE9VrId7Kt8hS7zvREVMTv1VfA6g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.1.1",
+                "@smithy/shared-ini-file-loader": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
+            "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.1.1",
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/querystring-builder": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.1.tgz",
+            "integrity": "sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
+            "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
+            "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-uri-escape": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
+            "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.1.tgz",
+            "integrity": "sha512-Iam75b/JNXyDE41UvrlM6n8DNOa/r1ylFyvgruTUx7h2Uk7vDNV9AAwP1vfL1fOL8ls0xArwEGVcGZVd7IO/Cw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.1.1.tgz",
+            "integrity": "sha512-YkpikhIqGc4sfXeIbzSj10t2bJI/sSoP5qxLue6zG+tEE3ngOBSm8sO3+djacYvS/R5DfpxN/L9CyZsvwjWOAQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
+            "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.1.0",
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-hex-encoding": "^4.1.0",
+                "@smithy/util-middleware": "^4.1.1",
+                "@smithy/util-uri-escape": "^4.1.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.1.tgz",
+            "integrity": "sha512-WolVLDb9UTPMEPPOncrCt6JmAMCSC/V2y5gst2STWJ5r7+8iNac+EFYQnmvDCYMfOLcilOSEpm5yXZXwbLak1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.11.0",
+                "@smithy/middleware-endpoint": "^4.2.1",
+                "@smithy/middleware-stack": "^4.1.1",
+                "@smithy/protocol-http": "^5.2.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-stream": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz",
+            "integrity": "sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
+            "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
+            "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.1.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
+            "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.1.0.tgz",
+            "integrity": "sha512-BOI5dYjheZdgR9XiEM3HJcEMCXSoqbzu7CzIgYrx0UtmvtC3tC2iDGpJLsSRFffUpy8ymsg2ARMP5fR8mtuUQQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
+            "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.1.0.tgz",
+            "integrity": "sha512-swXz2vMjrP1ZusZWVTB/ai5gK+J8U0BWvP10v9fpcFvg+Xi/87LHvHfst2IgCs1i0v4qFZfGwCmeD/KNCdJZbQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.1.tgz",
+            "integrity": "sha512-hA1AKIHFUMa9Tl6q6y8p0pJ9aWHCCG8s57flmIyLE0W7HcJeYrYtnqXDcGnftvXEhdQnSexyegXnzzTGk8bKLA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.1.1",
+                "@smithy/smithy-client": "^4.6.1",
+                "@smithy/types": "^4.5.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.1.tgz",
+            "integrity": "sha512-RGSpmoBrA+5D2WjwtK7tto6Pc2wO9KSXKLpLONhFZ8VyuCbqlLdiDAfuDTNY9AJe4JoE+Cx806cpTQQoQ71zPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.2.1",
+                "@smithy/credential-provider-imds": "^4.1.1",
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/property-provider": "^4.1.1",
+                "@smithy/smithy-client": "^4.6.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.1.tgz",
+            "integrity": "sha512-qB4R9kO0SetA11Rzu6MVGFIaGYX3p6SGGGfWwsKnC6nXIf0n/0AKVwRTsYsz9ToN8CeNNtNgQRwKFBndGJZdyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.2.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
+            "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.1.tgz",
+            "integrity": "sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.1.tgz",
+            "integrity": "sha512-jGeybqEZ/LIordPLMh5bnmnoIgsqnp4IEimmUp5c5voZ8yx+5kAlN5+juyr7p+f7AtZTgvhmInQk4Q0UVbrZ0Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.1.tgz",
+            "integrity": "sha512-khKkW/Jqkgh6caxMWbMuox9+YfGlsk9OnHOYCGVEdYQb/XVzcORXHLYUubHmmda0pubEDncofUrPNniS9d+uAA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.2.1",
+                "@smithy/node-http-handler": "^4.2.1",
+                "@smithy/types": "^4.5.0",
+                "@smithy/util-base64": "^4.1.0",
+                "@smithy/util-buffer-from": "^4.1.0",
+                "@smithy/util-hex-encoding": "^4.1.0",
+                "@smithy/util-utf8": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
+            "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
+            "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.1.1.tgz",
+            "integrity": "sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.1.1",
+                "@smithy/types": "^4.5.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1726,6 +3716,12 @@
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/uuid": {
+            "version": "9.0.8",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+            "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
             "license": "MIT"
         },
         "node_modules/@types/yaml": {
@@ -2939,6 +4935,12 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/bowser": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+            "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+            "license": "MIT"
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4106,6 +6108,24 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -6926,6 +8946,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7152,9 +9184,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/src/cdk/package.json
+++ b/src/cdk/package.json
@@ -10,7 +10,8 @@
         "test": "jest",
         "cdk": "cdk",
         "docs": "typedoc",
-        "docs:wiki": "typedoc --out ./wiki-docs"
+        "docs:wiki": "typedoc --out ./wiki-docs",
+        "cleanup": "ts-node scripts/cleanup-resources.ts"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",
@@ -36,6 +37,12 @@
         "@aws-cdk/aws-applicationsignals-alpha": "^2.214.0-alpha.0",
         "@aws-cdk/aws-lambda-python-alpha": "2.214.0-alpha.0",
         "@aws-cdk/lambda-layer-kubectl-v33": "^2.0.0",
+        "@aws-sdk/client-cloudwatch-logs": "^3.0.0",
+        "@aws-sdk/client-ec2": "^3.0.0",
+        "@aws-sdk/client-ecs": "^3.0.0",
+        "@aws-sdk/client-rds": "^3.0.0",
+        "@aws-sdk/client-resource-groups-tagging-api": "^3.0.0",
+        "@aws-sdk/client-s3": "^3.0.0",
         "@types/yaml": "^1.9.7",
         "aws-cdk": "^2.1029.0",
         "aws-cdk-lib": "2.214.0",

--- a/src/cdk/scripts/cleanup-resources.ts
+++ b/src/cdk/scripts/cleanup-resources.ts
@@ -1,0 +1,1487 @@
+#!/usr/bin/env ts-node
+
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * AWS Resource Cleanup Script for One Observability Workshop
+ *
+ * This script identifies and deletes AWS resources that are tagged with the workshop tags
+ * but may not have been properly cleaned up when stacks were deleted.
+ *
+ * Usage:
+ *   npm run cleanup -- --stack-name <STACK_NAME>
+ *   npm run cleanup -- --discover
+ *   npm run cleanup -- --stack-name <STACK_NAME> --dry-run
+ */
+
+import { CloudWatchLogsClient, DeleteLogGroupCommand } from '@aws-sdk/client-cloudwatch-logs';
+import { EC2Client, DescribeVolumesCommand, DeleteVolumeCommand, DeleteSnapshotCommand } from '@aws-sdk/client-ec2';
+import { RDSClient, DeleteDBClusterSnapshotCommand, DeleteDBSnapshotCommand } from '@aws-sdk/client-rds';
+import { ECSClient, DeregisterTaskDefinitionCommand } from '@aws-sdk/client-ecs';
+import { S3Client, ListObjectVersionsCommand, DeleteObjectsCommand, DeleteBucketCommand } from '@aws-sdk/client-s3';
+import { ResourceGroupsTaggingAPIClient, GetResourcesCommand } from '@aws-sdk/client-resource-groups-tagging-api';
+import { throttlingBackOff } from './utils/throttle-backoff';
+
+interface CleanupOptions {
+    stackName?: string;
+    discover: boolean;
+    dryRun: boolean;
+    region?: string;
+    skipConfirmation?: boolean;
+    cleanupMissingTags?: boolean;
+}
+
+interface ResourceCounts {
+    cloudwatchLogs: number;
+    ebsVolumes: number;
+    ebsSnapshots: number;
+    rdsBackups: number;
+    ecsTaskDefinitions: number;
+    s3Buckets: number;
+}
+
+export const TAGS = {
+    environment: 'non-prod',
+    application: 'One Observability Workshop',
+    stackName: process.env.STACK_NAME || 'MissingStackName',
+};
+
+class WorkshopResourceCleanup {
+    private cloudWatchLogs: CloudWatchLogsClient;
+    private ec2: EC2Client;
+    private rds: RDSClient;
+    private ecs: ECSClient;
+    private s3: S3Client;
+    private resourceGroupsTagging: ResourceGroupsTaggingAPIClient;
+    private region: string;
+
+    private readonly WORKSHOP_TAGS = TAGS;
+
+    constructor(region: string = process.env.AWS_REGION || 'us-east-1') {
+        const clientConfig = { region };
+        this.region = region;
+
+        this.cloudWatchLogs = new CloudWatchLogsClient(clientConfig);
+        this.ec2 = new EC2Client(clientConfig);
+        this.rds = new RDSClient(clientConfig);
+        this.ecs = new ECSClient(clientConfig);
+        this.s3 = new S3Client(clientConfig);
+        this.resourceGroupsTagging = new ResourceGroupsTaggingAPIClient(clientConfig);
+    }
+
+    /**
+     * Get AWS account and region information
+     */
+    async getAwsAccountInfo(): Promise<{ accountId: string | undefined; region: string }> {
+        try {
+            // Try to get account ID from any AWS resource ARN
+            const command = new GetResourcesCommand({
+                ResourcesPerPage: 1,
+            });
+
+            const response = await throttlingBackOff(() => this.resourceGroupsTagging.send(command));
+
+            let accountId: string | undefined;
+            if (response.ResourceTagMappingList && response.ResourceTagMappingList.length > 0) {
+                const arn = response.ResourceTagMappingList[0].ResourceARN;
+                if (arn) {
+                    // Extract account ID from ARN (format: arn:aws:service:region:account-id:resource)
+                    const arnParts = arn.split(':');
+                    if (arnParts.length >= 5) {
+                        accountId = arnParts[4];
+                    }
+                }
+            }
+
+            return {
+                accountId,
+                region: this.region,
+            };
+        } catch {
+            return {
+                accountId: undefined,
+                region: this.region,
+            };
+        }
+    }
+
+    /**
+     * Discover all unique stack names from resources with workshop tags
+     */
+    async discoverStackNames(): Promise<string[]> {
+        console.log('🔍 Discovering stack names from existing resources...\n');
+
+        const stackNames = new Set<string>();
+
+        try {
+            // First, try to find resources with both environment AND application tags
+            console.log('   Searching for resources with both environment and application tags...');
+            await this.searchResourcesWithTags(
+                [
+                    {
+                        Key: 'environment',
+                        Values: [this.WORKSHOP_TAGS.environment],
+                    },
+                    {
+                        Key: 'application',
+                        Values: [this.WORKSHOP_TAGS.application],
+                    },
+                ],
+                stackNames,
+            );
+
+            // If no stack names found, fallback to searching by application tag only
+            if (stackNames.size === 0) {
+                console.log('   No resources found with both tags. Falling back to application tag only...');
+                await this.searchResourcesWithTags(
+                    [
+                        {
+                            Key: 'application',
+                            Values: [this.WORKSHOP_TAGS.application],
+                        },
+                    ],
+                    stackNames,
+                );
+            }
+
+            if (stackNames.size === 0) {
+                console.log('   No workshop resources found with required tags.');
+            } else {
+                console.log(`   Found ${stackNames.size} unique stack name(s).`);
+            }
+        } catch (error) {
+            console.error('❌ Error discovering stack names:', error);
+        }
+
+        return [...stackNames].sort();
+    }
+
+    /**
+     * Helper method to search for resources with given tag filters
+     */
+    private async searchResourcesWithTags(
+        tagFilters: Array<{ Key: string; Values: string[] }>,
+        stackNames: Set<string>,
+    ): Promise<void> {
+        let nextToken: string | undefined;
+        do {
+            const commandWithToken = new GetResourcesCommand({
+                TagFilters: tagFilters,
+                ...(nextToken && { PaginationToken: nextToken }),
+            });
+
+            const response = await throttlingBackOff(() => this.resourceGroupsTagging.send(commandWithToken));
+
+            if (response.ResourceTagMappingList) {
+                for (const resource of response.ResourceTagMappingList) {
+                    // First try to find explicit stackName tag
+                    const stackNameTag = resource.Tags?.find(
+                        (tag: { Key?: string; Value?: string }) => tag.Key === 'stackName',
+                    );
+
+                    if (stackNameTag?.Value && stackNameTag.Value !== 'MissingStackName') {
+                        stackNames.add(stackNameTag.Value);
+                    } else {
+                        // Fallback: Extract stack name from resource ARN patterns
+                        const extractedStackName = this.extractStackNameFromArn(resource.ResourceARN || '');
+                        if (extractedStackName) {
+                            stackNames.add(extractedStackName);
+                        }
+                    }
+                }
+            }
+
+            nextToken = response.PaginationToken;
+        } while (nextToken);
+    }
+
+    /**
+     * Extract stack name from ARN when stackName tag is missing
+     */
+    private extractStackNameFromArn(arn: string): string | undefined {
+        if (!arn) return undefined;
+
+        // Common patterns in One Observability Workshop ARNs:
+        // arn:aws:ecs:region:account:task-definition/DevMicroservicesStacktrafficgeneratortaskDefinition5F5740DD:3
+        // arn:aws:ecs:region:account:task-definition/OneObservabilityMicroservicesMicroservicepetfoodrstaskDefinition693030E6:1
+
+        const patterns = [
+            // ECS Task Definition pattern: extract stack name from task definition name
+            /task-definition\/([^:\/]+)/,
+            // Lambda function pattern: extract from function name
+            /function:([^:]+)/,
+            // CloudWatch log group pattern: extract from log group name
+            /log-group:([^:]+)/,
+            // S3 bucket pattern: extract from bucket name
+            /:::([^\/]+)/,
+            // EBS volume/snapshot pattern: extract from tags or name
+            /volume\/(.+)|snapshot\/(.+)/,
+            // RDS pattern: extract from DB identifier
+            /db:([^:]+)|cluster:([^:]+)/,
+        ];
+
+        for (const pattern of patterns) {
+            const match = arn.match(pattern);
+            if (match) {
+                const resourceName = match[1] || match[2] || match[3];
+                if (resourceName) {
+                    // Extract potential stack name from resource name
+                    // Look for common stack name patterns
+                    const stackPatterns = [
+                        // Match patterns like "DevMicroservicesStack", "OneObservabilityMicroservices", etc.
+                        /^(Dev\w*Stack|OneObservability\w*)/,
+                        // Match patterns ending with "Stack"
+                        /^(\w*Stack)/,
+                        // Match CDK-style stack names
+                        /^([A-Z][a-zA-Z0-9]*Stack)/,
+                    ];
+
+                    for (const stackPattern of stackPatterns) {
+                        const stackMatch = resourceName.match(stackPattern);
+                        if (stackMatch) {
+                            return stackMatch[1];
+                        }
+                    }
+
+                    // If no stack pattern found, try to extract meaningful prefix
+                    if (resourceName.includes('Dev') || resourceName.includes('OneObservability')) {
+                        // For names like "DevMicroservicesStacktrafficgenerator"
+                        const prefixMatch = resourceName.match(/^(Dev\w*|OneObservability\w*)/);
+                        if (prefixMatch) {
+                            return prefixMatch[1];
+                        }
+                    }
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Get workshop resources using Resource Groups API
+     */
+    private async getWorkshopResources(
+        resourceType: string,
+        stackName?: string,
+        checkMode: 'exact' | 'missing-stackname' | 'application-only' = 'exact',
+    ): Promise<string[]> {
+        const resources: string[] = [];
+        let nextToken: string | undefined;
+
+        try {
+            const tagFilters = [];
+
+            switch (checkMode) {
+                case 'exact': {
+                    tagFilters.push(
+                        { Key: 'environment', Values: [this.WORKSHOP_TAGS.environment] },
+                        { Key: 'application', Values: [this.WORKSHOP_TAGS.application] },
+                    );
+                    if (stackName) {
+                        tagFilters.push({ Key: 'stackName', Values: [stackName] });
+                    }
+                    break;
+                }
+
+                case 'missing-stackname': {
+                    tagFilters.push(
+                        { Key: 'environment', Values: [this.WORKSHOP_TAGS.environment] },
+                        { Key: 'application', Values: [this.WORKSHOP_TAGS.application] },
+                    );
+                    // Note: We'll filter out resources WITH stackName after getting results
+                    break;
+                }
+
+                case 'application-only': {
+                    tagFilters.push({ Key: 'application', Values: [this.WORKSHOP_TAGS.application] });
+                    break;
+                }
+            }
+
+            do {
+                const command = new GetResourcesCommand({
+                    ResourceTypeFilters: [resourceType],
+                    TagFilters: tagFilters,
+                    ...(nextToken && { PaginationToken: nextToken }),
+                });
+
+                const response = await throttlingBackOff(() => this.resourceGroupsTagging.send(command));
+
+                if (response.ResourceTagMappingList) {
+                    for (const resource of response.ResourceTagMappingList) {
+                        if (!resource.ResourceARN) continue;
+
+                        // For missing-stackname mode, filter out resources that have valid stackName
+                        if (checkMode === 'missing-stackname') {
+                            const stackNameTag = resource.Tags?.find(
+                                (tag: { Key?: string; Value?: string }) => tag.Key === 'stackName',
+                            );
+                            if (stackNameTag?.Value && stackNameTag.Value !== 'MissingStackName') {
+                                continue; // Skip resources with valid stackName
+                            }
+                        }
+
+                        resources.push(resource.ResourceARN);
+                    }
+                }
+
+                nextToken = response.PaginationToken;
+            } while (nextToken);
+        } catch (error) {
+            console.error(`❌ Error getting workshop resources for ${resourceType}:`, error);
+        }
+
+        return resources;
+    }
+
+    /**
+     * Extract resource identifier from ARN based on resource type
+     */
+    private extractResourceId(arn: string, resourceType: string): string | undefined {
+        const parts = arn.split(':');
+
+        switch (resourceType) {
+            case 'logs:log-group': {
+                // arn:aws:logs:region:account:log-group:NAME:*
+                return parts.length >= 6 ? parts.slice(6).join(':').replace(/:\*$/, '') : undefined;
+            }
+
+            case 'ec2:volume':
+            case 'ec2:snapshot': {
+                // arn:aws:ec2:region:account:volume/vol-xxx or snapshot/snap-xxx
+                return parts.length >= 6 ? parts[5].split('/')[1] : undefined;
+            }
+
+            case 'rds:db-snapshot':
+            case 'rds:cluster-snapshot': {
+                // arn:aws:rds:region:account:snapshot:name or cluster-snapshot:name
+                return parts.length >= 6 ? parts[6] : undefined;
+            }
+
+            case 'ecs:task-definition': {
+                // arn:aws:ecs:region:account:task-definition/family:revision
+                return parts.length >= 6 ? parts[5].split('/')[1] : undefined;
+            }
+
+            case 's3:bucket': {
+                // arn:aws:s3:::bucket-name
+                return parts.length >= 6 ? parts[5] : undefined;
+            }
+
+            default: {
+                return undefined;
+            }
+        }
+    }
+
+    /**
+     * Check if resource has matching workshop tags (legacy method for compatibility)
+     */
+    private hasWorkshopTags(
+        tags: Array<{ Key?: string; key?: string; Value?: string; value?: string }>,
+        stackName?: string,
+        checkMode: 'exact' | 'missing-stackname' | 'application-only' = 'exact',
+    ): boolean {
+        const tagMap = new Map(tags.map((tag) => [tag.Key || tag.key, tag.Value || tag.value]));
+
+        const hasRequiredTags =
+            tagMap.get('environment') === this.WORKSHOP_TAGS.environment &&
+            tagMap.get('application') === this.WORKSHOP_TAGS.application;
+
+        const hasApplicationTag = tagMap.get('application') === this.WORKSHOP_TAGS.application;
+        const hasStackNameTag = tagMap.has('stackName') && tagMap.get('stackName') !== 'MissingStackName';
+
+        switch (checkMode) {
+            case 'exact': {
+                if (stackName) {
+                    return hasRequiredTags && tagMap.get('stackName') === stackName;
+                }
+                return hasRequiredTags;
+            }
+
+            case 'missing-stackname': {
+                // Resources that have workshop tags but missing valid stackName
+                return hasRequiredTags && !hasStackNameTag;
+            }
+
+            case 'application-only': {
+                // Resources that have application tag (fallback mode)
+                return hasApplicationTag;
+            }
+
+            default: {
+                return hasRequiredTags;
+            }
+        }
+    }
+
+    /**
+     * Check for resources with missing stackName tags
+     */
+    async checkForResourcesWithMissingStackName(): Promise<{
+        hasResources: boolean;
+        count: number;
+        resourceTypes: string[];
+    }> {
+        console.log('🔍 Checking for resources with missing stackName tags...\n');
+
+        const resourceTypes: string[] = [];
+        let totalCount = 0;
+
+        try {
+            // Check CloudWatch Logs
+            process.stdout.write('   📋 Checking CloudWatch Log Groups...');
+            const cwCount = await this.countResourcesWithMissingStackName('logs:log-group');
+            console.log(` found ${cwCount}`);
+            if (cwCount > 0) {
+                resourceTypes.push(`CloudWatch Log Groups (${cwCount})`);
+                totalCount += cwCount;
+            }
+
+            // Check EBS Volumes
+            process.stdout.write('   💾 Checking EBS Volumes...');
+            const ebsVolCount = await this.countResourcesWithMissingStackName('ec2:volume');
+            console.log(` found ${ebsVolCount}`);
+            if (ebsVolCount > 0) {
+                resourceTypes.push(`EBS Volumes (${ebsVolCount})`);
+                totalCount += ebsVolCount;
+            }
+
+            // Check EBS Snapshots
+            process.stdout.write('   📸 Checking EBS Snapshots...');
+            const ebsSnapCount = await this.countResourcesWithMissingStackName('ec2:snapshot');
+            console.log(` found ${ebsSnapCount}`);
+            if (ebsSnapCount > 0) {
+                resourceTypes.push(`EBS Snapshots (${ebsSnapCount})`);
+                totalCount += ebsSnapCount;
+            }
+
+            // Check RDS Backups (DB snapshots)
+            process.stdout.write('   🗄️ Checking RDS Backups...');
+            const rdsDatabaseCount = await this.countResourcesWithMissingStackName('rds:db-snapshot');
+            const rdsClusterCount = await this.countResourcesWithMissingStackName('rds:cluster-snapshot');
+            const rdsCount = rdsDatabaseCount + rdsClusterCount;
+            console.log(` found ${rdsCount}`);
+            if (rdsCount > 0) {
+                resourceTypes.push(`RDS Backups (${rdsCount})`);
+                totalCount += rdsCount;
+            }
+
+            // Check ECS Task Definitions
+            process.stdout.write('   📋 Checking ECS Task Definitions...');
+            const ecsCount = await this.countResourcesWithMissingStackName('ecs:task-definition');
+            console.log(` found ${ecsCount}`);
+            if (ecsCount > 0) {
+                resourceTypes.push(`ECS Task Definitions (${ecsCount})`);
+                totalCount += ecsCount;
+            }
+
+            // Check S3 Buckets
+            process.stdout.write('   🪣 Checking S3 Buckets...');
+            const s3Count = await this.countResourcesWithMissingStackName('s3:bucket');
+            console.log(` found ${s3Count}`);
+            if (s3Count > 0) {
+                resourceTypes.push(`S3 Buckets (${s3Count})`);
+                totalCount += s3Count;
+            }
+
+            console.log(); // Add blank line after progress indicators
+
+            return {
+                hasResources: totalCount > 0,
+                count: totalCount,
+                resourceTypes,
+            };
+        } catch (error) {
+            console.error('❌ Error checking for resources:', error);
+            return { hasResources: false, count: 0, resourceTypes: [] };
+        }
+    }
+
+    /**
+     * Count resources with missing stackName tag using Resource Groups API
+     */
+    private async countResourcesWithMissingStackName(resourceType: string): Promise<number> {
+        const resources = await this.getWorkshopResources(resourceType, undefined, 'missing-stackname');
+        return resources.length;
+    }
+
+    /**
+     * Clean up CloudWatch Log Groups
+     */
+    async cleanupCloudWatchLogs(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('🗂️  Cleaning up CloudWatch Log Groups...');
+
+        let deletedCount = 0;
+        const resourceType = 'logs:log-group';
+
+        try {
+            const resources = await this.getWorkshopResources(resourceType, stackName);
+
+            for (const resourceArn of resources) {
+                const logGroupName = this.extractResourceId(resourceArn, resourceType);
+
+                if (!logGroupName) {
+                    console.log(`   ⚠️ Could not extract log group name from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete log group: ${logGroupName}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.cloudWatchLogs.send(new DeleteLogGroupCommand({ logGroupName })),
+                        );
+                        console.log(`   ✅ Deleted log group: ${logGroupName}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete log group ${logGroupName}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up CloudWatch logs:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Clean up EBS Volumes
+     */
+    async cleanupEBSVolumes(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('💾 Cleaning up EBS Volumes...');
+
+        let deletedCount = 0;
+        const resourceType = 'ec2:volume';
+
+        try {
+            const resources = await this.getWorkshopResources(resourceType, stackName);
+
+            for (const resourceArn of resources) {
+                const volumeId = this.extractResourceId(resourceArn, resourceType);
+
+                if (!volumeId) {
+                    console.log(`   ⚠️ Could not extract volume ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                // Check if volume exists and is available (not attached)
+                try {
+                    const describeCommand = new DescribeVolumesCommand({ VolumeIds: [volumeId] });
+                    const describeResponse = await throttlingBackOff(() => this.ec2.send(describeCommand));
+
+                    const volume = describeResponse.Volumes?.[0];
+                    if (!volume) {
+                        console.log(`   ⚠️ Volume ${volumeId} not found in describe response, skipping`);
+                        continue;
+                    }
+
+                    if (volume.State !== 'available') {
+                        console.log(`   ⚠️ Skipping volume ${volumeId} because it is in ${volume.State} state`);
+                        continue;
+                    }
+                } catch (error: unknown) {
+                    const errorObject = error as { name?: string; Code?: string; message?: string };
+                    if (
+                        errorObject.name === 'InvalidVolume.NotFound' ||
+                        errorObject.Code === 'InvalidVolume.NotFound'
+                    ) {
+                        console.log(`   ⚠️ Volume ${volumeId} no longer exists, skipping`);
+                        continue;
+                    }
+                    console.error(`   ❌ Error checking volume ${volumeId}: ${errorObject.message || String(error)}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete EBS volume: ${volumeId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() => this.ec2.send(new DeleteVolumeCommand({ VolumeId: volumeId })));
+                        console.log(`   ✅ Deleted EBS volume: ${volumeId}`);
+                    } catch (error: unknown) {
+                        const errorObject = error as { name?: string; Code?: string; message?: string };
+                        if (
+                            errorObject.name === 'InvalidVolume.NotFound' ||
+                            errorObject.Code === 'InvalidVolume.NotFound'
+                        ) {
+                            console.log(`   ⚠️ Volume ${volumeId} was already deleted, continuing`);
+                        } else {
+                            console.error(
+                                `   ❌ Failed to delete volume ${volumeId}: ${errorObject.message || String(error)}`,
+                            );
+                        }
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up EBS volumes:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Clean up EBS Snapshots
+     */
+    async cleanupEBSSnapshots(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('📸 Cleaning up EBS Snapshots...');
+
+        let deletedCount = 0;
+        const resourceType = 'ec2:snapshot';
+
+        try {
+            const resources = await this.getWorkshopResources(resourceType, stackName);
+
+            for (const resourceArn of resources) {
+                const snapshotId = this.extractResourceId(resourceArn, resourceType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete EBS snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.ec2.send(new DeleteSnapshotCommand({ SnapshotId: snapshotId })),
+                        );
+                        console.log(`   ✅ Deleted EBS snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up EBS snapshots:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Clean up RDS Backups (DB Snapshots and Cluster Snapshots)
+     */
+    async cleanupRDSBackups(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('🗄️  Cleaning up RDS Backups...');
+
+        let deletedCount = 0;
+
+        try {
+            // Clean up DB snapshots
+            const databaseSnapshotType = 'rds:db-snapshot';
+            const databaseSnapshots = await this.getWorkshopResources(databaseSnapshotType, stackName);
+
+            for (const resourceArn of databaseSnapshots) {
+                const snapshotId = this.extractResourceId(resourceArn, databaseSnapshotType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract DB snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete DB snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.rds.send(new DeleteDBSnapshotCommand({ DBSnapshotIdentifier: snapshotId })),
+                        );
+                        console.log(`   ✅ Deleted DB snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete DB snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+
+            // Clean up DB cluster snapshots
+            const clusterSnapshotType = 'rds:cluster-snapshot';
+            const clusterSnapshots = await this.getWorkshopResources(clusterSnapshotType, stackName);
+
+            for (const resourceArn of clusterSnapshots) {
+                const snapshotId = this.extractResourceId(resourceArn, clusterSnapshotType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract cluster snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete DB cluster snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.rds.send(
+                                new DeleteDBClusterSnapshotCommand({ DBClusterSnapshotIdentifier: snapshotId }),
+                            ),
+                        );
+                        console.log(`   ✅ Deleted DB cluster snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete cluster snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up RDS backups:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Clean up ECS Task Definitions
+     */
+    async cleanupECSTaskDefinitions(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('📋 Cleaning up ECS Task Definitions...');
+
+        let deletedCount = 0;
+        const resourceType = 'ecs:task-definition';
+
+        try {
+            const resources = await this.getWorkshopResources(resourceType, stackName);
+
+            for (const resourceArn of resources) {
+                const taskDefinition = resourceArn; // For task definitions, we use the full ARN
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would deregister task definition: ${taskDefinition}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.ecs.send(new DeregisterTaskDefinitionCommand({ taskDefinition })),
+                        );
+                        console.log(`   ✅ Deregistered task definition: ${taskDefinition}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to deregister task definition ${taskDefinition}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up ECS task definitions:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Clean up S3 Buckets (with emptying)
+     */
+    async cleanupS3Buckets(stackName: string, dryRun: boolean): Promise<number> {
+        console.log('🪣 Cleaning up S3 Buckets...');
+
+        let deletedCount = 0;
+        const resourceType = 's3:bucket';
+
+        try {
+            const resources = await this.getWorkshopResources(resourceType, stackName);
+
+            for (const resourceArn of resources) {
+                const bucketName = this.extractResourceId(resourceArn, resourceType);
+
+                if (!bucketName) {
+                    console.log(`   ⚠️ Could not extract bucket name from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would empty and delete S3 bucket: ${bucketName}`);
+                } else {
+                    try {
+                        // First empty the bucket
+                        await this.emptyS3Bucket(bucketName);
+
+                        // Then delete the bucket
+                        await throttlingBackOff(() => this.s3.send(new DeleteBucketCommand({ Bucket: bucketName })));
+                        console.log(`   ✅ Deleted S3 bucket: ${bucketName}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete bucket ${bucketName}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                deletedCount++;
+            }
+        } catch (error) {
+            console.error('❌ Error cleaning up S3 buckets:', error);
+        }
+
+        return deletedCount;
+    }
+
+    /**
+     * Empty S3 bucket by deleting all objects and versions
+     */
+    private async emptyS3Bucket(bucketName: string): Promise<void> {
+        console.log(`   🗂️  Emptying S3 bucket: ${bucketName}`);
+
+        try {
+            let isTruncated = true;
+            let keyMarker: string | undefined;
+            let versionIdMarker: string | undefined;
+
+            while (isTruncated) {
+                const listCommand = new ListObjectVersionsCommand({
+                    Bucket: bucketName,
+                    KeyMarker: keyMarker,
+                    VersionIdMarker: versionIdMarker,
+                    MaxKeys: 1000,
+                });
+
+                const listResponse = await throttlingBackOff(() => this.s3.send(listCommand));
+
+                const objects: Array<{ Key: string; VersionId?: string }> = [];
+
+                // Add current versions
+                if (listResponse.Versions) {
+                    objects.push(
+                        ...listResponse.Versions.map((version) => ({
+                            Key: version.Key!,
+                            VersionId: version.VersionId,
+                        })),
+                    );
+                }
+
+                // Add delete markers
+                if (listResponse.DeleteMarkers) {
+                    objects.push(
+                        ...listResponse.DeleteMarkers.map((marker) => ({
+                            Key: marker.Key!,
+                            VersionId: marker.VersionId,
+                        })),
+                    );
+                }
+
+                // Delete objects in batches
+                if (objects.length > 0) {
+                    const deleteCommand = new DeleteObjectsCommand({
+                        Bucket: bucketName,
+                        Delete: {
+                            Objects: objects,
+                            Quiet: true,
+                        },
+                    });
+
+                    await throttlingBackOff(() => this.s3.send(deleteCommand));
+                    console.log(`     Deleted ${objects.length} objects`);
+                }
+
+                isTruncated = listResponse.IsTruncated || false;
+                keyMarker = listResponse.NextKeyMarker;
+                versionIdMarker = listResponse.NextVersionIdMarker;
+            }
+        } catch (error: unknown) {
+            console.error(
+                `   ❌ Failed to empty bucket ${bucketName}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            throw error;
+        }
+    }
+
+    /**
+     * Run complete cleanup for a specific stack
+     */
+    async cleanupStack(stackName: string, dryRun: boolean = false): Promise<ResourceCounts> {
+        console.log(`\n🧹 ${dryRun ? '[DRY RUN] ' : ''}Cleaning up resources for stack: ${stackName}\n`);
+
+        const counts: ResourceCounts = {
+            cloudwatchLogs: 0,
+            ebsVolumes: 0,
+            ebsSnapshots: 0,
+            rdsBackups: 0,
+            ecsTaskDefinitions: 0,
+            s3Buckets: 0,
+        };
+
+        // Clean up resources in parallel for better performance
+        const cleanupPromises = [
+            this.cleanupCloudWatchLogs(stackName, dryRun),
+            this.cleanupEBSVolumes(stackName, dryRun),
+            this.cleanupEBSSnapshots(stackName, dryRun),
+            this.cleanupRDSBackups(stackName, dryRun),
+            this.cleanupECSTaskDefinitions(stackName, dryRun),
+            this.cleanupS3Buckets(stackName, dryRun),
+        ];
+
+        try {
+            const results = await Promise.all(cleanupPromises);
+
+            counts.cloudwatchLogs = results[0];
+            counts.ebsVolumes = results[1];
+            counts.ebsSnapshots = results[2];
+            counts.rdsBackups = results[3];
+            counts.ecsTaskDefinitions = results[4];
+            counts.s3Buckets = results[5];
+        } catch (error) {
+            console.error('❌ Error during cleanup:', error);
+        }
+
+        return counts;
+    }
+
+    /**
+     * Run cleanup for resources without stackName tag
+     */
+    async cleanupResourcesWithoutStackNameTag(dryRun: boolean = false): Promise<ResourceCounts> {
+        console.log(`\n🧹 ${dryRun ? '[DRY RUN] ' : ''}Cleaning up resources without valid stackName tags\n`);
+
+        const counts: ResourceCounts = {
+            cloudwatchLogs: 0,
+            ebsVolumes: 0,
+            ebsSnapshots: 0,
+            rdsBackups: 0,
+            ecsTaskDefinitions: 0,
+            s3Buckets: 0,
+        };
+
+        try {
+            // Clean up CloudWatch Logs without stackName
+            console.log('🗂️  Cleaning up CloudWatch Log Groups without stackName...');
+            const resourceType = 'logs:log-group';
+            const logGroups = await this.getWorkshopResources(resourceType, undefined, 'missing-stackname');
+
+            for (const resourceArn of logGroups) {
+                const logGroupName = this.extractResourceId(resourceArn, resourceType);
+
+                if (!logGroupName) {
+                    console.log(`   ⚠️ Could not extract log group name from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete log group: ${logGroupName}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.cloudWatchLogs.send(new DeleteLogGroupCommand({ logGroupName })),
+                        );
+                        console.log(`   ✅ Deleted log group: ${logGroupName}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete log group ${logGroupName}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.cloudwatchLogs++;
+            }
+
+            // Clean up EBS Volumes without stackName
+            console.log('💾 Cleaning up EBS Volumes without stackName...');
+            const volumeType = 'ec2:volume';
+            const volumes = await this.getWorkshopResources(volumeType, undefined, 'missing-stackname');
+
+            for (const resourceArn of volumes) {
+                const volumeId = this.extractResourceId(resourceArn, volumeType);
+
+                if (!volumeId) {
+                    console.log(`   ⚠️ Could not extract volume ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                // Check if volume exists and is available (not attached)
+                try {
+                    const describeCommand = new DescribeVolumesCommand({ VolumeIds: [volumeId] });
+                    const describeResponse = await throttlingBackOff(() => this.ec2.send(describeCommand));
+
+                    const volume = describeResponse.Volumes?.[0];
+                    if (!volume) {
+                        console.log(`   ⚠️ Volume ${volumeId} not found in describe response, skipping`);
+                        continue;
+                    }
+
+                    if (volume.State !== 'available') {
+                        console.log(`   ⚠️ Skipping volume ${volumeId} because it is in ${volume.State} state`);
+                        continue;
+                    }
+                } catch (error: unknown) {
+                    const errorObject = error as { name?: string; Code?: string; message?: string };
+                    if (
+                        errorObject.name === 'InvalidVolume.NotFound' ||
+                        errorObject.Code === 'InvalidVolume.NotFound'
+                    ) {
+                        console.log(`   ⚠️ Volume ${volumeId} no longer exists, skipping`);
+                        continue;
+                    }
+                    console.error(`   ❌ Error checking volume ${volumeId}: ${errorObject.message || String(error)}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete EBS volume: ${volumeId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() => this.ec2.send(new DeleteVolumeCommand({ VolumeId: volumeId })));
+                        console.log(`   ✅ Deleted EBS volume: ${volumeId}`);
+                    } catch (error: unknown) {
+                        const errorObject = error as { name?: string; Code?: string; message?: string };
+                        if (
+                            errorObject.name === 'InvalidVolume.NotFound' ||
+                            errorObject.Code === 'InvalidVolume.NotFound'
+                        ) {
+                            console.log(`   ⚠️ Volume ${volumeId} was already deleted, continuing`);
+                        } else {
+                            console.error(
+                                `   ❌ Failed to delete volume ${volumeId}: ${errorObject.message || String(error)}`,
+                            );
+                        }
+                        continue;
+                    }
+                }
+                counts.ebsVolumes++;
+            }
+
+            // Clean up EBS Snapshots without stackName
+            console.log('📸 Cleaning up EBS Snapshots without stackName...');
+            const snapshotType = 'ec2:snapshot';
+            const snapshots = await this.getWorkshopResources(snapshotType, undefined, 'missing-stackname');
+
+            for (const resourceArn of snapshots) {
+                const snapshotId = this.extractResourceId(resourceArn, snapshotType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete EBS snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.ec2.send(new DeleteSnapshotCommand({ SnapshotId: snapshotId })),
+                        );
+                        console.log(`   ✅ Deleted EBS snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.ebsSnapshots++;
+            }
+
+            // Clean up RDS Backups without stackName
+            console.log('🗄️  Cleaning up RDS Backups without stackName...');
+
+            // Clean up DB snapshots
+            const databaseSnapshotType = 'rds:db-snapshot';
+            const databaseSnapshots = await this.getWorkshopResources(
+                databaseSnapshotType,
+                undefined,
+                'missing-stackname',
+            );
+
+            for (const resourceArn of databaseSnapshots) {
+                const snapshotId = this.extractResourceId(resourceArn, databaseSnapshotType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract DB snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete DB snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.rds.send(new DeleteDBSnapshotCommand({ DBSnapshotIdentifier: snapshotId })),
+                        );
+                        console.log(`   ✅ Deleted DB snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete DB snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.rdsBackups++;
+            }
+
+            // Clean up DB cluster snapshots
+            const clusterSnapshotType = 'rds:cluster-snapshot';
+            const clusterSnapshots = await this.getWorkshopResources(
+                clusterSnapshotType,
+                undefined,
+                'missing-stackname',
+            );
+
+            for (const resourceArn of clusterSnapshots) {
+                const snapshotId = this.extractResourceId(resourceArn, clusterSnapshotType);
+
+                if (!snapshotId) {
+                    console.log(`   ⚠️ Could not extract cluster snapshot ID from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would delete DB cluster snapshot: ${snapshotId}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.rds.send(
+                                new DeleteDBClusterSnapshotCommand({ DBClusterSnapshotIdentifier: snapshotId }),
+                            ),
+                        );
+                        console.log(`   ✅ Deleted DB cluster snapshot: ${snapshotId}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete cluster snapshot ${snapshotId}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.rdsBackups++;
+            }
+
+            // Clean up ECS Task Definitions without stackName
+            console.log('📋 Cleaning up ECS Task Definitions without stackName...');
+            const taskDefinitionType = 'ecs:task-definition';
+            const taskDefinitions = await this.getWorkshopResources(taskDefinitionType, undefined, 'missing-stackname');
+
+            for (const resourceArn of taskDefinitions) {
+                const taskDefinition = resourceArn; // For task definitions, we use the full ARN
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would deregister task definition: ${taskDefinition}`);
+                } else {
+                    try {
+                        await throttlingBackOff(() =>
+                            this.ecs.send(new DeregisterTaskDefinitionCommand({ taskDefinition })),
+                        );
+                        console.log(`   ✅ Deregistered task definition: ${taskDefinition}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to deregister task definition ${taskDefinition}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.ecsTaskDefinitions++;
+            }
+
+            // Clean up S3 Buckets without stackName
+            console.log('🪣 Cleaning up S3 Buckets without stackName...');
+            const bucketType = 's3:bucket';
+            const buckets = await this.getWorkshopResources(bucketType, undefined, 'missing-stackname');
+
+            for (const resourceArn of buckets) {
+                const bucketName = this.extractResourceId(resourceArn, bucketType);
+
+                if (!bucketName) {
+                    console.log(`   ⚠️ Could not extract bucket name from ARN: ${resourceArn}`);
+                    continue;
+                }
+
+                if (dryRun) {
+                    console.log(`   [DRY RUN] Would empty and delete S3 bucket: ${bucketName}`);
+                } else {
+                    try {
+                        // First empty the bucket
+                        await this.emptyS3Bucket(bucketName);
+
+                        // Then delete the bucket
+                        await throttlingBackOff(() => this.s3.send(new DeleteBucketCommand({ Bucket: bucketName })));
+                        console.log(`   ✅ Deleted S3 bucket: ${bucketName}`);
+                    } catch (error: unknown) {
+                        console.error(
+                            `   ❌ Failed to delete bucket ${bucketName}: ${error instanceof Error ? error.message : String(error)}`,
+                        );
+                        continue;
+                    }
+                }
+                counts.s3Buckets++;
+            }
+
+            return counts;
+        } catch (error) {
+            console.error('❌ Error during cleanup of resources without stackName:', error);
+            return counts;
+        }
+    }
+}
+
+/**
+ * Parse command line arguments
+ */
+function parseArguments(): CleanupOptions {
+    const arguments_ = process.argv.slice(2);
+    const options: CleanupOptions = {
+        discover: false,
+        dryRun: false,
+    };
+
+    for (let index = 0; index < arguments_.length; index++) {
+        const argument = arguments_[index];
+
+        switch (argument) {
+            case '--stack-name': {
+                options.stackName = arguments_[++index];
+                break;
+            }
+            case '--discover': {
+                options.discover = true;
+                break;
+            }
+            case '--dry-run': {
+                options.dryRun = true;
+                break;
+            }
+            case '--region': {
+                options.region = arguments_[++index];
+                break;
+            }
+            case '--skip-confirmation': {
+                options.skipConfirmation = true;
+                break;
+            }
+            case '--cleanup-missing-tags': {
+                options.cleanupMissingTags = true;
+                break;
+            }
+            case '--help': {
+                showHelp();
+                process.exit(0);
+                break;
+            }
+            default: {
+                if (argument.startsWith('--')) {
+                    console.error(`❌ Unknown option: ${argument}`);
+                    showHelp();
+                    process.exit(1);
+                }
+            }
+        }
+    }
+
+    return options;
+}
+
+/**
+ * Show help message
+ */
+function showHelp(): void {
+    console.log(`
+🧹 AWS Resource Cleanup Script for One Observability Workshop
+
+USAGE:
+    npm run cleanup -- [OPTIONS]
+
+OPTIONS:
+    --stack-name <name>       Specific stack name to clean up
+    --discover                List all found workshop stack names
+    --dry-run                 Preview what would be deleted (recommended)
+    --region <region>         AWS region (default: us-east-1 or AWS_REGION)
+    --cleanup-missing-tags    Clean up resources without valid stackName tags
+    --skip-confirmation       Skip confirmation prompts (use with caution)
+    --help                    Show this help message
+
+EXAMPLES:
+    # Discover all workshop stack names
+    npm run cleanup -- --discover
+
+    # Preview cleanup for a specific stack (RECOMMENDED FIRST STEP)
+    npm run cleanup -- --stack-name MyWorkshopStack --dry-run
+
+    # Actually perform the cleanup
+    npm run cleanup -- --stack-name MyWorkshopStack
+
+    # Clean up resources without valid stackName tags
+    npm run cleanup -- --cleanup-missing-tags --dry-run
+
+    # Clean up in a specific region
+    npm run cleanup -- --stack-name MyWorkshopStack --region us-west-2
+
+⚠️  SAFETY NOTICE:
+    This script performs destructive operations that cannot be undone!
+    Always run with --dry-run first to see what would be deleted.
+`);
+}
+
+/**
+ * Print summary report
+ */
+function printSummary(counts: ResourceCounts, dryRun: boolean): void {
+    const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+
+    console.log(`\n📊 ${dryRun ? '[DRY RUN] ' : ''}Cleanup Summary:`);
+    console.log(`   CloudWatch Log Groups: ${counts.cloudwatchLogs}`);
+    console.log(`   EBS Volumes: ${counts.ebsVolumes}`);
+    console.log(`   EBS Snapshots: ${counts.ebsSnapshots}`);
+    console.log(`   RDS Backups: ${counts.rdsBackups}`);
+    console.log(`   ECS Task Definitions: ${counts.ecsTaskDefinitions}`);
+    console.log(`   S3 Buckets: ${counts.s3Buckets}`);
+    console.log(`   Total Resources: ${total}`);
+
+    if (total === 0) {
+        console.log('\n✨ No resources found to clean up!');
+    } else if (dryRun) {
+        console.log(`\n⚠️  This was a dry run. To actually delete these ${total} resources, run without --dry-run`);
+    } else {
+        console.log(`\n✅ Successfully cleaned up ${total} resources!`);
+    }
+}
+
+/**
+ * Prompt for user confirmation
+ */
+async function promptConfirmation(stackName: string, dryRun: boolean): Promise<boolean> {
+    if (dryRun) return true;
+
+    const { createInterface } = await import('node:readline');
+    return new Promise((resolve) => {
+        const readline = createInterface({
+            input: process.stdin,
+            output: process.stdout,
+        });
+
+        readline.question(
+            `\n⚠️  You are about to DELETE resources for stack "${stackName}". This action cannot be undone!\n` +
+                'Type "yes" to continue or anything else to cancel: ',
+            (answer: string) => {
+                readline.close();
+                resolve(answer.toLowerCase() === 'yes');
+            },
+        );
+    });
+}
+
+/**
+ * Main execution function
+ */
+async function main(): Promise<void> {
+    try {
+        const options = parseArguments();
+
+        // Validate options
+        if (!options.discover && !options.stackName && !options.cleanupMissingTags) {
+            console.error('❌ Error: Must provide either --stack-name <name>, --discover, or --cleanup-missing-tags');
+            showHelp();
+            process.exit(1);
+        }
+
+        console.log('🧹 AWS Resource Cleanup Script for One Observability Workshop\n');
+
+        // Initialize cleanup service
+        const cleanup = new WorkshopResourceCleanup(options.region);
+
+        // Display AWS account and region information
+        try {
+            const awsInfo = await cleanup.getAwsAccountInfo();
+            console.log('📍 AWS Configuration:');
+            console.log(`   Account ID: ${awsInfo.accountId || 'Unable to determine'}`);
+            console.log(`   Region: ${awsInfo.region}`);
+            console.log();
+        } catch {
+            console.log('📍 AWS Configuration:');
+            console.log(`   Account ID: Unable to determine`);
+            console.log(`   Region: ${options.region || 'us-east-1'}`);
+            console.log();
+        }
+
+        if (options.discover) {
+            // Discovery mode
+            const stackNames = await cleanup.discoverStackNames();
+
+            if (stackNames.length === 0) {
+                console.log('No workshop resources found.');
+                console.log('\nTo clean up resources without proper stackName tags, run:');
+                console.log('npm run cleanup -- --cleanup-missing-tags --dry-run');
+            } else {
+                console.log('\nFound the following workshop stack names:');
+                for (const stackName of stackNames) {
+                    console.log(`   • ${stackName}`);
+                }
+
+                console.log('\nTo clean up a specific stack, run:');
+                console.log('npm run cleanup -- --stack-name <STACK_NAME> --dry-run');
+                console.log('\nTo clean up resources without proper stackName tags, run:');
+                console.log('npm run cleanup -- --cleanup-missing-tags --dry-run');
+            }
+        } else if (options.cleanupMissingTags) {
+            // Clean up resources without stackName tags
+            console.log('Checking for resources with missing or invalid stackName tags...\n');
+
+            const missingTagsCheck = await cleanup.checkForResourcesWithMissingStackName();
+
+            if (!missingTagsCheck.hasResources) {
+                console.log('✨ No resources found with missing stackName tags!');
+                return;
+            }
+
+            console.log(`Found ${missingTagsCheck.count} resources with missing stackName tags:`);
+            for (const resourceType of missingTagsCheck.resourceTypes) {
+                console.log(`   • ${resourceType}`);
+            }
+
+            if (!options.skipConfirmation) {
+                const confirmed = await promptConfirmation('resources without stackName tags', options.dryRun);
+                if (!confirmed) {
+                    console.log('❌ Operation cancelled by user.');
+                    process.exit(0);
+                }
+            }
+
+            const counts = await cleanup.cleanupResourcesWithoutStackNameTag(options.dryRun);
+            printSummary(counts, options.dryRun);
+        } else if (options.stackName) {
+            // Stack-specific cleanup
+            if (!options.skipConfirmation) {
+                const confirmed = await promptConfirmation(options.stackName, options.dryRun);
+                if (!confirmed) {
+                    console.log('❌ Operation cancelled by user.');
+                    process.exit(0);
+                }
+            }
+
+            const counts = await cleanup.cleanupStack(options.stackName, options.dryRun);
+            printSummary(counts, options.dryRun);
+        }
+    } catch (error) {
+        console.error('\n❌ Fatal error during cleanup:', error);
+        process.exit(1);
+    }
+}
+
+// Run the script if executed directly
+if (require.main === module) {
+    // eslint-disable-next-line unicorn/prefer-top-level-await
+    (async () => {
+        try {
+            await main();
+        } catch (error) {
+            console.error('❌ Unhandled error:', error);
+            process.exit(1);
+        }
+    })();
+}

--- a/src/cdk/scripts/utils/throttle-backoff.ts
+++ b/src/cdk/scripts/utils/throttle-backoff.ts
@@ -1,0 +1,47 @@
+/**
+ * Utility function for handling AWS throttling errors with exponential backoff
+ * Retries API calls with increasing delays when throttling errors occur
+ */
+export async function throttlingBackOff<T>(
+    callback: () => Promise<T>,
+    maxRetries: number = 5,
+    initialDelay: number = 500,
+    maxDelay: number = 5000,
+): Promise<T> {
+    let retries = 0;
+    let delay = initialDelay;
+
+    while (true) {
+        try {
+            return await callback();
+        } catch (error: unknown) {
+            // Check if error is throttling-related
+            const isThrottling =
+                error instanceof Error &&
+                (error.name === 'ThrottlingException' ||
+                    error.name === 'TooManyRequestsException' ||
+                    error.name === 'Throttling' ||
+                    error.name === 'RequestLimitExceeded' ||
+                    (error as { code?: string }).code === 'RequestThrottled' ||
+                    error.message.includes('Rate exceeded'));
+
+            if (!isThrottling || retries >= maxRetries) {
+                throw error;
+            }
+
+            // Exponential backoff with jitter
+            delay = Math.min(delay * 2, maxDelay);
+            const jitter = Math.random() * (delay / 4);
+            const waitTime = delay + jitter;
+
+            // Log throttling for debugging
+            console.log(
+                `⏳ Throttling detected, retrying in ${Math.round(waitTime / 100) / 10}s... (Retry ${retries + 1}/${maxRetries})`,
+            );
+
+            // Wait before retrying
+            await new Promise((resolve) => setTimeout(resolve, waitTime));
+            retries++;
+        }
+    }
+}


### PR DESCRIPTION
- Added comprehensive cleanup script for One Observability Workshop resources
- Implemented cleanup for CloudWatch logs, EBS volumes/snapshots, RDS backups, ECS task definitions, and S3 buckets
- Added throttling backoff utility for handling AWS API rate limits
- Supports dry-run mode, stack discovery, and cleanup of untagged resources
- Added documentation for cleanup script usage and safety guidelines
- Updated package.json with cleanup script command and new AWS SDK dependencies

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
