### PR TITLE
impr: petfood env management and cleanup

### DIFF
--- a/src/applications/microservices/petfood-rs/src/config/mod.rs
+++ b/src/applications/microservices/petfood-rs/src/config/mod.rs
@@ -253,12 +253,17 @@ impl Config {
         );
 
         // Test foods table
-        match self.aws.dynamodb_client.describe_table()
+        match self
+            .aws
+            .dynamodb_client
+            .describe_table()
             .table_name(&self.database.foods_table_name)
             .send()
-            .await {
+            .await
+        {
             Ok(response) => {
-                let table_status = response.table()
+                let table_status = response
+                    .table()
                     .and_then(|t| t.table_status())
                     .map(|s| s.as_str())
                     .unwrap_or("unknown");
@@ -279,12 +284,17 @@ impl Config {
         }
 
         // Test carts table
-        match self.aws.dynamodb_client.describe_table()
+        match self
+            .aws
+            .dynamodb_client
+            .describe_table()
             .table_name(&self.database.carts_table_name)
             .send()
-            .await {
+            .await
+        {
             Ok(response) => {
-                let table_status = response.table()
+                let table_status = response
+                    .table()
                     .and_then(|t| t.table_status())
                     .map(|s| s.as_str())
                     .unwrap_or("unknown");
@@ -457,8 +467,7 @@ pub(crate) fn default_carts_table() -> String {
 
 pub(crate) fn default_region() -> String {
     // Use the standard AWS_REGION environment variable provided by ECS
-    std::env::var("AWS_REGION")
-        .unwrap_or_else(|_| "us-west-2".to_string())
+    std::env::var("AWS_REGION").unwrap_or_else(|_| "us-west-2".to_string())
 }
 
 pub(crate) fn default_assets_cdn_url() -> String {

--- a/src/applications/microservices/petfood-rs/src/handlers/api.rs
+++ b/src/applications/microservices/petfood-rs/src/handlers/api.rs
@@ -70,7 +70,6 @@ pub fn create_api_router(
         )
         .route("/api/cart/:user_id/clear", post(clear_cart))
         .route("/api/cart/:user_id/checkout", post(checkout_cart))
-        .route("/api/cart/:user_id/summary", get(get_cart_summary))
         .with_state(state)
 }
 
@@ -293,34 +292,6 @@ pub async fn clear_cart(
         }
     }
 }
-
-#[instrument(skip(state))]
-pub async fn get_cart_summary(
-    State(state): State<ApiState>,
-    Path(user_id): Path<String>,
-) -> Result<Json<CartSummaryResponse>, (StatusCode, Json<Value>)> {
-    info!("Getting cart summary for user: {}", user_id);
-
-    // Get cart details
-    let cart = match state.cart_service.get_cart(&user_id).await {
-        Ok(cart) => cart,
-        Err(err) => {
-            error!("Failed to get cart for summary: {}", err);
-            return Err(service_error_to_response(err));
-        }
-    };
-
-    let summary = CartSummaryResponse {
-        user_id: cart.user_id,
-        total_items: cart.total_items,
-        total_price: cart.total_price,
-        is_empty: cart.total_items == 0,
-    };
-
-    info!("Successfully retrieved cart summary");
-    Ok(Json(summary))
-}
-
 
 /// Delete the entire cart
 #[instrument(name = "delete_cart", skip(state), fields(

--- a/src/applications/microservices/petfood-rs/src/main.rs
+++ b/src/applications/microservices/petfood-rs/src/main.rs
@@ -196,7 +196,6 @@ fn create_app(
         )
         .route("/api/cart/:user_id/clear", post(api::clear_cart))
         .route("/api/cart/:user_id/checkout", post(api::checkout_cart))
-        .route("/api/cart/:user_id/summary", get(api::get_cart_summary))
         .with_state(api_state)
         // Admin endpoints (with admin state)
         .route("/api/admin/setup-tables", post(admin::setup_tables))

--- a/src/applications/microservices/petfood-rs/src/main.rs
+++ b/src/applications/microservices/petfood-rs/src/main.rs
@@ -196,6 +196,7 @@ fn create_app(
         )
         .route("/api/cart/:user_id/clear", post(api::clear_cart))
         .route("/api/cart/:user_id/checkout", post(api::checkout_cart))
+        .route("/api/cart/:user_id/summary", get(api::get_cart_summary))
         .with_state(api_state)
         // Admin endpoints (with admin state)
         .route("/api/admin/setup-tables", post(admin::setup_tables))

--- a/src/applications/microservices/petfood-rs/src/main.rs
+++ b/src/applications/microservices/petfood-rs/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cart_service = Arc::new(CartService::new(
         cart_repository,
         food_repository,
-        config.database.assets_cdn_url.clone(),
+        config.database.images_cdn_url.clone(),
     ));
     info!("Services initialized successfully");
 
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         table_manager,
         config.database.foods_table_name.clone(),
         config.database.carts_table_name.clone(),
-        config.database.assets_cdn_url.clone(),
+        config.database.images_cdn_url.clone(),
     );
 
     // Create socket address

--- a/src/applications/microservices/petfood-rs/src/repositories/cart_repository.rs
+++ b/src/applications/microservices/petfood-rs/src/repositories/cart_repository.rs
@@ -302,9 +302,7 @@ impl DynamoDbCartRepository {
                 );
             }
             "ServiceUnavailable" | "InternalServerError" => {
-                error!(
-                    "DynamoDB service unavailable - this may be a temporary AWS service issue"
-                );
+                error!("DynamoDB service unavailable - this may be a temporary AWS service issue");
             }
             _ => {
                 error!(

--- a/src/applications/microservices/petfood-rs/src/repositories/food_repository.rs
+++ b/src/applications/microservices/petfood-rs/src/repositories/food_repository.rs
@@ -476,9 +476,7 @@ impl DynamoDbFoodRepository {
                 );
             }
             "ServiceUnavailable" | "InternalServerError" => {
-                error!(
-                    "DynamoDB service unavailable - this may be a temporary AWS service issue"
-                );
+                error!("DynamoDB service unavailable - this may be a temporary AWS service issue");
             }
             _ => {
                 error!(


### PR DESCRIPTION
## Features
- Dropping dead code
- Resolve SSM dynamically while supporting normal local development

### behaviours expected (confirmed with unit tests)

**Local dev, passing all env variables**
```
% PETFOOD_CARTS_TABLE_NAME=cartsTable PETFOOD_FOODS_TABLE_NAME="MyTableName" PETFOOD_IMAGES_CDN_URL="localhost" cargo run

Loading configuration from environment and AWS Parameter Store
Initializing AWS configuration for region: us-west-2
AWS configuration loaded successfully
Using SSM parameter prefix: PETFOOD_SSM_PARAM_PREFIX=
Parameter resolved from environment (no SSM prefix): PETFOOD_FOODS_TABLE_NAME=MyTableName
Parameter resolved from environment (no SSM prefix): PETFOOD_CARTS_TABLE_NAME=cartsTable
Parameter resolved from environment (no SSM prefix): PETFOOD_IMAGES_CDN_URL=localhost
Database configuration resolved: foods_table=MyTableName, carts_table=cartsTable, assets_cdn_url=localhost
...
2025-09-13T17:24:25.744839Z  INFO DynamoDB Tables: foods=MyTableName, carts=cartsTable
...
2025-09-13T17:24:25.746521Z  INFO Server listening on 0.0.0.0:8080
```

**Looking for SSM Parameters (based on Prefix being present)** 

App is crashing cause no AWS creds, would be the same if env doesn't exists

```
% PETFOOD_SSM_PARAM_PREFIX=/doesntexists PETFOOD_CARTS_TABLE_NAME=cartsTable PETFOOD_FOODS_TABLE_NAME="MyTableName" PETFOOD_IMAGES_CDN_URL="localhost" cargo run

Loading configuration from environment and AWS Parameter Store
Initializing AWS configuration for region: us-west-2
AWS configuration loaded successfully
Using SSM parameter prefix: PETFOOD_SSM_PARAM_PREFIX=/doesntexists
Parameter PETFOOD_FOODS_TABLE_NAME not found in SSM path /doesntexists/MyTableName (AWS SDK error: dispatch failure)
Parameter PETFOOD_FOODS_TABLE_NAME using default (SSM prefix configured but failed)
Parameter PETFOOD_CARTS_TABLE_NAME not found in SSM path /doesntexists/cartsTable (AWS SDK error: dispatch failure)
Parameter PETFOOD_CARTS_TABLE_NAME using default (SSM prefix configured but failed)
Parameter PETFOOD_IMAGES_CDN_URL not found in SSM path /doesntexists/localhost (AWS SDK error: dispatch failure)
Parameter PETFOOD_IMAGES_CDN_URL using default (SSM prefix configured but failed)
Database configuration resolved: foods_table=, carts_table=, assets_cdn_url=
Error: ValidationError { message: "Foods table name cannot be empty" }
```

**Happy path with SSM**

```
% PETFOOD_SSM_PARAM_PREFIX=/petstore PETFOOD_CARTS_TABLE_NAME=carts_table_name PETFOOD_FOODS_TABLE_NAME=foods_table_name PETFOOD_IMAGES_CDN_URL=imagescdnurl cargo run

Loading configuration from environment and AWS Parameter Store
Initializing AWS configuration for region: us-west-2
AWS configuration loaded successfully
Using SSM parameter prefix: PETFOOD_SSM_PARAM_PREFIX=/petstore
Parameter PETFOOD_FOODS_TABLE_NAME resolved from SSM path /petstore/foods_table_name: DevStorageStack-Dynamo<redacted>
Parameter PETFOOD_CARTS_TABLE_NAME resolved from SSM path /petstore/carts_table_name: DevStorageStack-Dynamo<redacted>
Parameter PETFOOD_IMAGES_CDN_URL resolved from SSM path /petstore/imagescdnurl: http://<redacted>.cloudfront.net
Database configuration resolved: foods_table=DevStorageStack-Dynamo<redacted>, carts_table=DevStorageStack-Dynamo<redacted>, assets_cdn_url=http://<redacted>.cloudfront.net
Configuration loaded successfully
Configuration loaded successfully
2025-09-13T17:42:04.057746Z  INFO Observability initialized successfully
2025-09-13T17:42:04.057789Z  INFO Starting petfood-rs service
2025-09-13T17:42:04.057796Z  INFO Service: petfood-rs v0.1.0
2025-09-13T17:42:04.057801Z  INFO Region: us-west-2
2025-09-13T17:42:04.057807Z  INFO DynamoDB Tables: foods=DevStorageStack-Dynamo<redacted>, carts=DevStorageStack-Dynamo<redacted>
...
2025-09-13T17:42:04.059087Z  INFO Server listening on 0.0.0.0:8080
```