### PR TITLE
upgrade to amazon-cloudwatch-observability addon version 4.4.0

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -509,7 +509,7 @@ export class Services extends Stack {
         // NOTE: Amazon CloudWatch Observability Addon for CloudWatch Agent and Fluentbit
         const otelAddon = new eks.CfnAddon(this, 'otelObservabilityAddon', {
             addonName: 'amazon-cloudwatch-observability',
-            addonVersion: 'v3.3.0-eksbuild.1',
+            addonVersion: 'v4.4.0-eksbuild.1',
             clusterName: cluster.clusterName,
             // the properties below are optional
             resolveConflicts: 'OVERWRITE',

--- a/gitops/git-repository.yaml
+++ b/gitops/git-repository.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m0s
-  url: https://github.com/aws-samples/one-observability-demo
+  # url: https://github.com/aws-samples/one-observability-demo
+  url: https://github.com/hibira/one-observability-demo/tree/issue/383
   ref:
     branch: main

--- a/gitops/git-repository.yaml
+++ b/gitops/git-repository.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: flux-system
 spec:
   interval: 5m0s
-  # url: https://github.com/aws-samples/one-observability-demo
-  url: https://github.com/hibira/one-observability-demo/tree/issue/383
+  url: https://github.com/aws-samples/one-observability-demo
   ref:
     branch: main


### PR DESCRIPTION
*Issue #, if available:*
#383 

*Description of changes:*
upgrade the CloudWatch Observability Addon version to the latest v4.4.0-eksbuild.1.
It has been confirmed that v4.4.0-eksbuild.1 can be used with the current kubernetes version 1.31.
```
% aws eks describe-addon-versions --addon-name amazon-cloudwatch-observability --kubernetes-version 1.31
{
    "addons": [
        {
            "addonName": "amazon-cloudwatch-observability",
            "type": "observability",
            "addonVersions": [
                {
                    "addonVersion": "v4.4.0-eksbuild.1",
                    "architecture": [
                        "amd64",
                        "arm64"
                    ],
                    "computeTypes": [
                        "ec2",
                        "hybrid",
                        "auto"
                    ],
                    "compatibilities": [
                        {
                            "clusterVersion": "1.31",
                            "platformVersions": [
                                "*"
                            ],
                            "defaultVersion": true
                        }
                    ],
                    "requiresConfiguration": false,
                    "requiresIamPermissions": true
                },
```

The following operation was confirmed.
- [x] Successful deployment
<img width="1917" height="473" alt="スクリーンショット 2025-09-15 22 35 54" src="https://github.com/user-attachments/assets/9651f2ca-c772-48a0-ab41-bb373e16f2a1" />

<img width="1588" height="248" alt="スクリーンショット 2025-09-15 21 23 08" src="https://github.com/user-attachments/assets/e367bec4-7ec3-481b-b4c0-656138e73adc" />

- [x] Container Insights will be reflected
<img width="1628" height="760" alt="スクリーンショット 2025-09-15 21 24 07" src="https://github.com/user-attachments/assets/e19161e6-407e-45a3-81ef-9fc81821ed03" />

- [x] X-Ray will be reflected
<img width="1027" height="471" alt="スクリーンショット 2025-09-15 21 56 29" src="https://github.com/user-attachments/assets/e780b906-84db-438c-8361-f6b5932a6787" />

- [x] If Application Signals is enabled, it will be reflected in Application Signals
<img width="1406" height="723" alt="スクリーンショット 2025-09-15 22 09 16" src="https://github.com/user-attachments/assets/b76063ce-45b6-4589-b248-53c928d576f3" />
<img width="1907" height="810" alt="スクリーンショット 2025-09-15 22 25 08" src="https://github.com/user-attachments/assets/426ff6d3-37af-4911-9568-b6cf4d880207" />
<img width="1915" height="824" alt="スクリーンショット 2025-09-15 22 25 39" src="https://github.com/user-attachments/assets/6a52c5fd-8a89-497f-988d-cfdf585aebcc" />




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
