### PR TITLE
refactor: improve CDK infrastructure maintainability and documentation

### DIFF
--- a/src/cdk/lib/constructs/cloudtrail.ts
+++ b/src/cdk/lib/constructs/cloudtrail.ts
@@ -16,7 +16,7 @@ import { Construct } from 'constructs';
 import { Trail, InsightType, CfnEventDataStore, CfnTrail } from 'aws-cdk-lib/aws-cloudtrail';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Role, ServicePrincipal, PolicyStatement, PolicyDocument } from 'aws-cdk-lib/aws-iam';
-import { Names, RemovalPolicy, Duration } from 'aws-cdk-lib';
+import { RemovalPolicy, Duration } from 'aws-cdk-lib';
 import { NagSuppressions } from 'cdk-nag';
 import { BlockPublicAccess, Bucket } from 'aws-cdk-lib/aws-s3';
 
@@ -58,11 +58,9 @@ export class WorkshopCloudTrail extends Construct {
     constructor(scope: Construct, id: string, properties: WorkshopCloudTrailProperties) {
         super(scope, id);
 
-        const logName = Names.uniqueResourceName(this, {});
         // Create CloudWatch log group for CloudTrail
         this.logGroup = new LogGroup(this, 'CloudTrailLogGroup', {
             retention: properties.logRetentionDays || RetentionDays.ONE_WEEK,
-            logGroupName: `/aws/cloudtrail/${logName}`,
             removalPolicy: RemovalPolicy.DESTROY,
         });
 

--- a/src/cdk/lib/constructs/database.ts
+++ b/src/cdk/lib/constructs/database.ts
@@ -158,21 +158,25 @@ export class AuroraDatabase extends Construct {
         new CfnOutput(this, 'ClusterArn', {
             value: this.cluster.clusterArn,
             exportName: AURORA_CLUSTER_ARN_EXPORT_NAME,
+            description: 'ARN of the Aurora PostgreSQL database cluster',
         });
 
         new CfnOutput(this, 'ClusterEndpoint', {
             value: this.cluster.clusterEndpoint.hostname,
             exportName: AURORA_CLUSTER_ENDPOINT_EXPORT_NAME,
+            description: 'Writer endpoint hostname for the Aurora PostgreSQL cluster',
         });
 
         new CfnOutput(this, 'SecurityGroupId', {
             value: this.databaseSecurityGroup.securityGroupId,
             exportName: AURORA_SECURITY_GROUP_ID_EXPORT_NAME,
+            description: 'Security group ID for Aurora PostgreSQL cluster access control',
         });
 
         new CfnOutput(this, 'AdminSecretArn', {
             value: this.cluster.secret!.secretArn,
             exportName: AURORA_ADMIN_SECRET_ARN_EXPORT_NAME,
+            description: 'Secrets Manager ARN containing Aurora admin credentials',
         });
     }
 

--- a/src/cdk/lib/constructs/dynamodb.ts
+++ b/src/cdk/lib/constructs/dynamodb.ts
@@ -147,31 +147,37 @@ export class DynamoDatabase extends Construct {
         new CfnOutput(this, 'TableArn', {
             value: this.petAdoptionTable.tableArn,
             exportName: DYNAMODB_TABLE_ARN_EXPORT_NAME,
+            description: 'ARN of the DynamoDB table for pet adoption data',
         });
 
         new CfnOutput(this, 'TableName', {
             value: this.petAdoptionTable.tableName,
             exportName: DYNAMODB_TABLE_NAME_EXPORT_NAME,
+            description: 'Name of the DynamoDB table for pet adoption data',
         });
 
         new CfnOutput(this, 'PetFoodsTableArn', {
             value: this.petFoodsTable.tableArn,
             exportName: `${DYNAMODB_TABLE_ARN_EXPORT_NAME}-PetFoods`,
+            description: 'ARN of the DynamoDB table for pet food products',
         });
 
         new CfnOutput(this, 'PetFoodsTableName', {
             value: this.petFoodsTable.tableName,
             exportName: `${DYNAMODB_TABLE_NAME_EXPORT_NAME}-PetFoods`,
+            description: 'Name of the DynamoDB table for pet food products',
         });
 
         new CfnOutput(this, 'PetFoodsCartTableArn', {
             value: this.petFoodsCartTable.tableArn,
             exportName: `${DYNAMODB_TABLE_ARN_EXPORT_NAME}-PetFoodsCart`,
+            description: 'ARN of the DynamoDB table for pet food shopping cart',
         });
 
         new CfnOutput(this, 'PetFoodsCartTableName', {
             value: this.petFoodsCartTable.tableName,
             exportName: `${DYNAMODB_TABLE_NAME_EXPORT_NAME}-PetFoodsCart`,
+            description: 'Name of the DynamoDB table for pet food shopping cart',
         });
     }
 

--- a/src/cdk/lib/constructs/ecs-service.ts
+++ b/src/cdk/lib/constructs/ecs-service.ts
@@ -103,7 +103,6 @@ export abstract class EcsService extends Microservice {
 
         // Create CloudWatch log group
         const logGroup = new LogGroup(this, 'ecs-log-group', {
-            logGroupName: properties.logGroupName || `/ecs/${properties.name}`,
             removalPolicy: RemovalPolicy.DESTROY,
             retention: properties.logRetentionDays || RetentionDays.ONE_WEEK,
         });
@@ -210,7 +209,7 @@ export abstract class EcsService extends Microservice {
             this.addAdotPythonInitContainer(taskDefinition, container);
 
             // Add CloudWatch agent sidecar
-            this.addCloudWatchAgentSidecar(taskDefinition, properties);
+            this.addCloudWatchAgentSidecar(taskDefinition);
         }
 
         if (!properties.disableService) {
@@ -474,7 +473,6 @@ export abstract class EcsService extends Microservice {
             logging: new AwsLogDriver({
                 streamPrefix: 'firelens',
                 logGroup: new LogGroup(this, 'firelens-log-group', {
-                    logGroupName: `/ecs/firelens/${properties.name}`,
                     removalPolicy: RemovalPolicy.DESTROY,
                     retention: RetentionDays.ONE_WEEK,
                 }),
@@ -568,7 +566,7 @@ export abstract class EcsService extends Microservice {
         });
     }
 
-    private addCloudWatchAgentSidecar(taskDefinition: TaskDefinition, properties: EcsServiceProperties): void {
+    private addCloudWatchAgentSidecar(taskDefinition: TaskDefinition): void {
         // CloudWatch agent configuration for Application Signals
         const cloudWatchConfig = {
             traces: {
@@ -592,7 +590,6 @@ export abstract class EcsService extends Microservice {
             logging: new AwsLogDriver({
                 streamPrefix: 'cloudwatch-agent',
                 logGroup: new LogGroup(this, 'cloudwatch-agent-log-group', {
-                    logGroupName: `/ecs/cloudwatch-agent/${properties.name}`,
                     removalPolicy: RemovalPolicy.DESTROY,
                     retention: RetentionDays.ONE_WEEK,
                 }),

--- a/src/cdk/lib/constructs/ecs.ts
+++ b/src/cdk/lib/constructs/ecs.ts
@@ -151,16 +151,19 @@ export class WorkshopEcs extends Construct {
         new CfnOutput(this, 'ClusterArn', {
             value: this.cluster.clusterArn,
             exportName: ECS_CLUSTER_ARN_EXPORT_NAME,
+            description: 'ARN of the ECS cluster for container deployments',
         });
 
         new CfnOutput(this, 'ClusterName', {
             value: this.cluster.clusterName,
             exportName: ECS_CLUSTER_NAME_EXPORT_NAME,
+            description: 'Name of the ECS cluster',
         });
 
         new CfnOutput(this, 'SecurityGroupId', {
             value: this.securityGroup.securityGroupId,
             exportName: ECS_SECURITY_GROUP_ID_EXPORT_NAME,
+            description: 'Security group ID for ECS cluster resources',
         });
     }
 

--- a/src/cdk/lib/constructs/eks.ts
+++ b/src/cdk/lib/constructs/eks.ts
@@ -235,36 +235,43 @@ export class WorkshopEks extends Construct {
         new CfnOutput(this, 'ClusterArn', {
             value: this.cluster.clusterArn,
             exportName: EKS_CLUSTER_ARN_EXPORT_NAME,
+            description: 'ARN of the EKS cluster',
         });
 
         new CfnOutput(this, 'ClusterName', {
             value: this.cluster.clusterName,
             exportName: EKS_CLUSTER_NAME_EXPORT_NAME,
+            description: 'Name of the EKS cluster for kubectl configuration',
         });
 
         new CfnOutput(this, 'SecurityGroupId', {
             value: this.cluster.clusterSecurityGroupId,
             exportName: EKS_SECURITY_GROUP_ID_EXPORT_NAME,
+            description: 'Security group ID for EKS cluster network access',
         });
 
         new CfnOutput(this, 'KubectlRoleArn', {
             value: this.cluster.kubectlRole!.roleArn,
             exportName: EKS_KUBECTL_ROLE_ARN_EXPORT_NAME,
+            description: 'IAM role ARN for kubectl operations on the EKS cluster',
         });
 
         new CfnOutput(this, 'OpenIdConnectProviderArn', {
             value: this.cluster.openIdConnectProvider.openIdConnectProviderArn,
             exportName: EKS_OPEN_ID_CONNECT_PROVIDER_ARN_EXPORT_NAME,
+            description: 'OIDC provider ARN for EKS service account IAM role integration',
         });
 
         new CfnOutput(this, 'KubectlSecurityGroupId', {
             value: this.cluster.kubectlSecurityGroup!.securityGroupId,
             exportName: EKS_KUBECTL_SECURITY_GROUP_ID_EXPORT_NAME,
+            description: 'Security group ID for kubectl Lambda function',
         });
 
         new CfnOutput(this, 'KubectlLambdaRoleArn', {
             value: this.cluster.kubectlLambdaRole!.roleArn,
             exportName: EKS_KUBECTL_LAMBDA_ROLE_ARN_EXPORT_NAME,
+            description: 'IAM role ARN for the kubectl Lambda function',
         });
     }
 

--- a/src/cdk/lib/constructs/eventbus.ts
+++ b/src/cdk/lib/constructs/eventbus.ts
@@ -75,10 +75,12 @@ export class EventBusResources extends Construct {
         new CfnOutput(this, 'EventBusArn', {
             value: this.eventBus.eventBusArn,
             exportName: EVENTBUS_ARN_EXPORT_NAME,
+            description: 'ARN of the EventBridge event bus for cross-service communication',
         });
         new CfnOutput(this, 'EventBusName', {
             value: this.eventBus.eventBusName,
             exportName: EVENTBUS_NAME_EXPORT_NAME,
+            description: 'Name of the EventBridge event bus',
         });
     }
 }

--- a/src/cdk/lib/constructs/microservice.ts
+++ b/src/cdk/lib/constructs/microservice.ts
@@ -42,7 +42,6 @@ export interface MicroserviceProperties {
     name: string;
     repositoryURI: string;
     disableService?: boolean;
-    logGroupName?: string;
     healthCheck?: string;
     subnetType?: SubnetType;
     listenerPort?: number;

--- a/src/cdk/lib/constructs/network.ts
+++ b/src/cdk/lib/constructs/network.ts
@@ -269,35 +269,50 @@ export class WorkshopNetwork extends Construct {
      * Creates CloudFormation outputs for VPC resources
      */
     private createVpcOutputs() {
-        new CfnOutput(this, 'VpcId', { value: this.vpc.vpcId, exportName: VPC_ID_EXPORT_NAME });
-        new CfnOutput(this, 'VpcCidr', { value: this.vpc.vpcCidrBlock, exportName: VPC_CIDR_EXPORT_NAME });
+        new CfnOutput(this, 'VpcId', {
+            value: this.vpc.vpcId,
+            exportName: VPC_ID_EXPORT_NAME,
+            description: 'VPC ID for the workshop network',
+        });
+        new CfnOutput(this, 'VpcCidr', {
+            value: this.vpc.vpcCidrBlock,
+            exportName: VPC_CIDR_EXPORT_NAME,
+            description: 'CIDR block of the workshop VPC',
+        });
         new CfnOutput(this, 'VpcPrivateSubnets', {
             value: this.vpc.privateSubnets.map((s) => s.subnetId).join(','),
             exportName: VPC_PRIVATE_SUBNETS_EXPORT_NAME,
+            description: 'Comma-separated list of private subnet IDs with NAT gateway access',
         });
         new CfnOutput(this, 'VpcPublicSubnets', {
             value: this.vpc.publicSubnets.map((s) => s.subnetId).join(','),
             exportName: VPC_PUBLIC_SUBNETS_EXPORT_NAME,
+            description: 'Comma-separated list of public subnet IDs with internet gateway access',
         });
         new CfnOutput(this, 'VpcIsolatedSubnets', {
             value: this.vpc.isolatedSubnets.map((s) => s.subnetId).join(','),
             exportName: VPC_ISOLATED_SUBNETS_EXPORT_NAME,
+            description: 'Comma-separated list of isolated subnet IDs without internet access',
         });
         new CfnOutput(this, 'VpcAvailabilityZones', {
             value: this.vpc.availabilityZones.join(','),
             exportName: VPC_AVAILABILITY_ZONES_EXPORT_NAME,
+            description: 'Comma-separated list of availability zones used by the VPC',
         });
         new CfnOutput(this, 'VpcPrivateSubnetCidrs', {
             value: this.vpc.privateSubnets.map((s) => s.ipv4CidrBlock).join(','),
             exportName: VPC_PRIVATE_SUBNET_CIDRS_EXPORT_NAME,
+            description: 'Comma-separated list of CIDR blocks for private subnets',
         });
         new CfnOutput(this, 'VpcPublicSubnetCidrs', {
             value: this.vpc.publicSubnets.map((s) => s.ipv4CidrBlock).join(','),
             exportName: VPC_PUBLIC_SUBNET_CIDRS_EXPORT_NAME,
+            description: 'Comma-separated list of CIDR blocks for public subnets',
         });
         new CfnOutput(this, 'VpcIsolatedSubnetCidrs', {
             value: this.vpc.isolatedSubnets.map((s) => s.ipv4CidrBlock).join(','),
             exportName: VPC_ISOLATED_SUBNET_CIDRS_EXPORT_NAME,
+            description: 'Comma-separated list of CIDR blocks for isolated subnets',
         });
     }
 
@@ -308,16 +323,19 @@ export class WorkshopNetwork extends Construct {
         new CfnOutput(this, 'CloudMapNamespaceId', {
             value: this.cloudMapNamespace.namespaceId,
             exportName: CLOUDMAP_NAMESPACE_ID_EXPORT_NAME,
+            description: 'Cloud Map namespace ID for service discovery',
         });
 
         new CfnOutput(this, 'CloudMapNamespaceName', {
             value: this.cloudMapNamespace.namespaceName,
             exportName: CLOUDMAP_NAMESPACE_NAME_EXPORT_NAME,
+            description: 'Cloud Map namespace name for service discovery',
         });
 
         new CfnOutput(this, 'CloudMapNamespaceArn', {
             value: this.cloudMapNamespace.namespaceArn,
             exportName: CLOUDMAP_NAMESPACE_ARN_EXPORT_NAME,
+            description: 'Cloud Map namespace ARN for service discovery',
         });
     }
 

--- a/src/cdk/lib/constructs/opensearch-application.ts
+++ b/src/cdk/lib/constructs/opensearch-application.ts
@@ -100,11 +100,13 @@ export class OpenSearchApplication extends Construct {
         new CfnOutput(this, 'ApplicationArn', {
             value: this.application.attrArn,
             exportName: OPENSEARCH_APPLICATION_ARN_EXPORT_NAME,
+            description: 'ARN of the OpenSearch UI application for data visualization',
         });
 
         new CfnOutput(this, 'ApplicationId', {
             value: this.application.attrId,
             exportName: OPENSEARCH_APPLICATION_ID_EXPORT_NAME,
+            description: 'ID of the OpenSearch UI application',
         });
     }
 

--- a/src/cdk/lib/constructs/opensearch-collection.ts
+++ b/src/cdk/lib/constructs/opensearch-collection.ts
@@ -177,22 +177,26 @@ export class OpenSearchCollection extends Construct {
         new CfnOutput(this, 'CollectionArn', {
             value: this.collection.attrArn,
             exportName: OPENSEARCH_COLLECTION_ARN_EXPORT_NAME,
+            description: 'ARN of the OpenSearch Serverless collection for log storage',
         });
 
         new CfnOutput(this, 'CollectionId', {
             value: this.collection.attrId,
             exportName: OPENSEARCH_COLLECTION_ID_EXPORT_NAME,
+            description: 'ID of the OpenSearch Serverless collection',
         });
 
         new CfnOutput(this, 'CollectionEndpoint', {
             value: this.collection.attrCollectionEndpoint,
             exportName: OPENSEARCH_COLLECTION_ENDPOINT_EXPORT_NAME,
+            description: 'HTTPS endpoint URL for the OpenSearch Serverless collection',
         });
 
         // Export access policy name for updates
         new CfnOutput(this, 'AccessPolicyName', {
             value: this.accessPolicy.name!,
             exportName: `${OPENSEARCH_COLLECTION_ARN_EXPORT_NAME}-AccessPolicy`,
+            description: 'Name of the data access policy for the OpenSearch collection',
         });
     }
 

--- a/src/cdk/lib/constructs/opensearch-pipeline.ts
+++ b/src/cdk/lib/constructs/opensearch-pipeline.ts
@@ -166,7 +166,6 @@ export class OpenSearchPipeline extends Construct {
         // Create CloudWatch log group for pipeline logs
         // OpenSearch Ingestion requires log groups to use /aws/vendedlogs/ prefix
         const logGroup = new LogGroup(this, 'PipelineLogGroup', {
-            logGroupName: `/aws/vendedlogs/opensearch-ingestion/${pipelineName}`,
             retention: RetentionDays.ONE_WEEK,
             removalPolicy: RemovalPolicy.DESTROY,
         });
@@ -271,16 +270,19 @@ log-pipeline:
         new CfnOutput(this, 'PipelineArn', {
             value: this.pipeline.attrPipelineArn,
             exportName: OPENSEARCH_PIPELINE_ARN_EXPORT_NAME,
+            description: 'ARN of the OpenSearch Ingestion pipeline for log processing',
         });
 
         new CfnOutput(this, 'PipelineEndpoint', {
             value: this.pipelineEndpoint,
             exportName: OPENSEARCH_PIPELINE_ENDPOINT_EXPORT_NAME,
+            description: 'HTTP endpoint URL for ingesting logs into the OpenSearch pipeline',
         });
 
         new CfnOutput(this, 'PipelineRoleArn', {
             value: this.pipelineRole.roleArn,
             exportName: OPENSEARCH_PIPELINE_ROLE_ARN_EXPORT_NAME,
+            description: 'IAM role ARN used by the OpenSearch Ingestion pipeline',
         });
     }
 

--- a/src/cdk/lib/constructs/queue.ts
+++ b/src/cdk/lib/constructs/queue.ts
@@ -116,14 +116,17 @@ export class QueueResources extends Construct {
         new CfnOutput(this, 'SNSTopicArn', {
             value: this.topic.topicArn,
             exportName: SNS_TOPIC_ARN_EXPORT_NAME,
+            description: 'ARN of the SNS topic for pet adoption notifications',
         });
         new CfnOutput(this, 'SQSQueueArn', {
             value: this.queue.queueArn,
             exportName: SQS_QUEUE_ARN_EXPORT_NAME,
+            description: 'ARN of the SQS queue for pet adoption messages',
         });
         new CfnOutput(this, 'SQSQueueUrl', {
             value: this.queue.queueUrl,
             exportName: SQS_QUEUE_URL_EXPORT_NAME,
+            description: 'URL of the SQS queue for sending and receiving messages',
         });
     }
 

--- a/src/cdk/lib/constructs/vpc-endpoints.ts
+++ b/src/cdk/lib/constructs/vpc-endpoints.ts
@@ -137,61 +137,73 @@ export class VpcEndpoints extends Construct {
         new CfnOutput(this, 'ApiGatewayEndpointId', {
             value: this.apiGatewayEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_APIGATEWAY_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for API Gateway private access',
         });
 
         new CfnOutput(this, 'DynamoDbEndpointId', {
             value: this.dynamoDbEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_DYNAMODB_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for DynamoDB private access',
         });
 
         new CfnOutput(this, 'LambdaEndpointId', {
             value: this.lambdaEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_LAMBDA_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for Lambda private access',
         });
 
         new CfnOutput(this, 'ServiceDiscoveryEndpointId', {
             value: this.serviceDiscoveryEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_SERVICEDISCOVERY_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for Cloud Map service discovery',
         });
 
         new CfnOutput(this, 'DataServiceDiscoveryEndpointId', {
             value: this.dataServiceDiscoveryEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_DATA_SERVICEDISCOVERY_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for Cloud Map data service discovery',
         });
 
         new CfnOutput(this, 'S3EndpointId', {
             value: this.s3Endpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_S3_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for S3 private access',
         });
 
         new CfnOutput(this, 'SSMEndpointId', {
             value: this.ssmEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_SSM_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for Systems Manager private access',
         });
 
         new CfnOutput(this, 'EC2MessagesEndpointId', {
             value: this.ec2MessagesEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_EC2MESSAGES_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for EC2 messages (SSM Session Manager)',
         });
 
         new CfnOutput(this, 'SSMMessagesEndpointId', {
             value: this.ssmMessagesEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_SSMMESSAGES_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for SSM messages (Session Manager)',
         });
 
         new CfnOutput(this, 'SecretsManagerEndpointId', {
             value: this.secretsManagerEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_SECRETSMANAGER_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for Secrets Manager private access',
         });
 
         new CfnOutput(this, 'CloudWatchMonitoringEndpointId', {
             value: this.cloudWatchMonitoringEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_CLOUDWATCH_MONITORING_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for CloudWatch monitoring metrics',
         });
 
         new CfnOutput(this, 'CloudWatchLogsEndpointId', {
             value: this.cloudWatchLogsEndpoint.vpcEndpointId,
             exportName: VPC_ENDPOINT_CLOUDWATCH_LOGS_ID_EXPORT_NAME,
+            description: 'VPC endpoint ID for CloudWatch Logs',
         });
     }
 

--- a/src/cdk/lib/constructs/waf.ts
+++ b/src/cdk/lib/constructs/waf.ts
@@ -1,4 +1,4 @@
-import { Names, RemovalPolicy } from 'aws-cdk-lib';
+import { RemovalPolicy } from 'aws-cdk-lib';
 import { CfnLoggingConfiguration, CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 import { Construct } from 'constructs';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
@@ -26,7 +26,6 @@ export class RegionalWaf extends Construct {
         const logGroup = new LogGroup(this, 'WAFv2RegionalLogGroup', {
             retention: properties.logRetention || RetentionDays.ONE_WEEK,
             removalPolicy: RemovalPolicy.DESTROY,
-            logGroupName: 'aws-waf-logs-regional-' + Names.uniqueId(this),
         });
 
         const webAcl = new CfnWebACL(this, 'WAFv2RegionalACL', {
@@ -101,7 +100,6 @@ export class GlobalWaf extends Construct {
         const logGroup = new LogGroup(this, 'WAFv2GlobalLogGroup', {
             retention: properties.logRetention || RetentionDays.ONE_WEEK,
             removalPolicy: RemovalPolicy.DESTROY,
-            logGroupName: 'aws-waf-logs-global-' + Names.uniqueId(this),
         });
         const webAcl = new CfnWebACL(this, 'WAFv2GlobalACL', {
             defaultAction: {

--- a/src/cdk/lib/microservices/petfood-agent.ts
+++ b/src/cdk/lib/microservices/petfood-agent.ts
@@ -189,7 +189,7 @@ export class PetFoodAgentConstruct extends Construct {
 
         new CfnOutput(this, 'AgentRuntimeArn', {
             value: this.agentRuntime.attrAgentRuntimeArn,
-            description: 'Agent Runtime ARN',
+            description: 'ARN of the Bedrock Agent Runtime for pet food recommendations',
         });
     }
 }

--- a/src/cdk/lib/microservices/petsite.ts
+++ b/src/cdk/lib/microservices/petsite.ts
@@ -297,6 +297,7 @@ export class PetSite extends EKSDeployment {
         new CfnOutput(this, 'PetSiteUrl', {
             value: `https://${this.distribution.distributionDomainName}`,
             exportName: 'PetSiteUrl',
+            description: 'The URL of the PetSite application',
         });
 
         if (this.loadBalancer) {

--- a/src/cdk/lib/pipeline.ts
+++ b/src/cdk/lib/pipeline.ts
@@ -399,6 +399,7 @@ export class CDKPipeline extends Stack {
         new CfnOutput(this, 'PipelineArn', {
             value: pipeline.pipeline.pipelineArn,
             exportName: 'PipelineArn',
+            description: 'ARN of the CI/CD pipeline for deploying workshop infrastructure',
         });
 
         /**

--- a/src/cdk/lib/serverless/functions/status-updater/status-updater.ts
+++ b/src/cdk/lib/serverless/functions/status-updater/status-updater.ts
@@ -12,7 +12,7 @@ import {
 import { Construct } from 'constructs';
 import { ManagedPolicy, PolicyDocument, Effect, PolicyStatement, StarPrincipal } from 'aws-cdk-lib/aws-iam';
 import { ILayerVersion, LayerVersion } from 'aws-cdk-lib/aws-lambda';
-import { Names, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { BundlingOptions } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { EndpointType, LambdaRestApi, LogGroupLogDestination, MethodLoggingLevel } from 'aws-cdk-lib/aws-apigateway';
 import { NagSuppressions } from 'cdk-nag';
@@ -35,7 +35,6 @@ export class StatusUpdatedService extends WokshopLambdaFunction {
         super(scope, id, properties);
 
         const accesLogs = new LogGroup(this, 'access-logs', {
-            logGroupName: `/aws/apigw/${Names.uniqueId(this)}`,
             retention: properties.logRetentionDays || RetentionDays.ONE_WEEK,
             removalPolicy: RemovalPolicy.DESTROY,
         });

--- a/src/cdk/lib/utils/workshop-nag-pack.ts
+++ b/src/cdk/lib/utils/workshop-nag-pack.ts
@@ -34,6 +34,16 @@ export class WorkshopNagPack extends NagPack {
             });
 
             this.applyRule({
+                ruleSuffixOverride: 'CWL3',
+                info: 'CloudWatch Log Groups should use dynamically generated names',
+                explanation:
+                    'Log groups with static names may cause conflicts when redeploying the stack. Use dynamically generated names instead.',
+                level: NagMessageLevel.ERROR,
+                rule: this.checkCloudWatchLogGroupName,
+                node: node,
+            });
+
+            this.applyRule({
                 ruleSuffixOverride: 'S3-1',
                 info: 'S3 Buckets should have deletion policy configured',
                 explanation:
@@ -83,6 +93,20 @@ export class WorkshopNagPack extends NagPack {
         if (node.cfnResourceType === 'AWS::Logs::LogGroup') {
             const deletionPolicy = node.cfnOptions.deletionPolicy;
             if (!deletionPolicy || deletionPolicy.toString() !== 'Delete') {
+                return NagRuleCompliance.NON_COMPLIANT;
+            }
+            return NagRuleCompliance.COMPLIANT;
+        }
+        return NagRuleCompliance.NOT_APPLICABLE;
+    };
+
+    private checkCloudWatchLogGroupName = (node: CfnResource): NagRuleResult => {
+        if (node.cfnResourceType === 'AWS::Logs::LogGroup') {
+            const logGroupName = NagRules.resolveIfPrimitive(
+                node,
+                (node as CfnResource & { logGroupName?: unknown }).logGroupName,
+            );
+            if (logGroupName && typeof logGroupName === 'string' && !logGroupName.includes('Ref')) {
                 return NagRuleCompliance.NON_COMPLIANT;
             }
             return NagRuleCompliance.COMPLIANT;

--- a/src/templates/codebuild-deployment-template.yaml
+++ b/src/templates/codebuild-deployment-template.yaml
@@ -139,6 +139,7 @@ Parameters:
     ConstraintDescription: 'Must match the allowable values for a Tag Key. This can
       only contain alphanumeric characters or special characters ( _ . : / = + -
       or @) up to 128 characters'
+    Default: awsApplication
 
   pUserDefinedTagValue3:
     Type: String
@@ -147,6 +148,7 @@ Parameters:
     ConstraintDescription: 'Must match the allowable values for a Tag Value. This
       can only contain alphanumeric characters or special characters ( _ . : / =
       + - or @) up to 256 characters'
+    Default: One Observabiity Workshop
 
   pUserDefinedTagKey4:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
- Remove hardcoded CloudWatch log group names to prevent deployment conflicts
- Add descriptive CloudFormation output descriptions for better resource identification
- Remove unused Names import and logGroupName parameters
- Add CDK-nag rule to enforce dynamic log group naming
- Set default values for CloudFormation template parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
