### PR TITLE
Update ADOT collector to v1beta1 API with v0.47.0 image

### DIFF
--- a/src/cdk/scripts/build-otel-ecr.sh
+++ b/src/cdk/scripts/build-otel-ecr.sh
@@ -36,7 +36,7 @@ cat > config.yaml <<EOF
 extensions:
   sigv4auth:
     region: $REGION
-        
+
 receivers:
   # Prometheus scraping
   prometheus:
@@ -51,7 +51,7 @@ receivers:
         static_configs:
         - targets: [ "127.0.0.1:8080" ]
         metrics_path: "/metrics"
-  
+
   # ECS container metrics
   awsecscontainermetrics:
     collection_interval: 15s
@@ -87,7 +87,7 @@ service:
       receivers: [prometheus]
       processors: [resourcedetection, batch/metrics]
       exporters: [prometheusremotewrite, debug]
-    
+
     # ECS container metrics pipeline
     metrics/ecs:
       receivers: [awsecscontainermetrics]

--- a/src/cdk/scripts/otel-collector-prometheus.yaml
+++ b/src/cdk/scripts/otel-collector-prometheus.yaml
@@ -17,7 +17,7 @@ spec:
       sigv4auth:
         region: AWS_REGION
         service: aps
-    
+
     receivers:
       prometheus:
         config:
@@ -166,7 +166,7 @@ spec:
               source_labels:
               - __meta_kubernetes_pod_node_name
               target_label: kubernetes_node
-            
+
           - job_name: prometheus-pushgateway
             honor_labels: true
             kubernetes_sd_configs:
@@ -293,7 +293,7 @@ spec:
               regex: Pending|Succeeded|Failed|Completed
               source_labels:
               - __meta_kubernetes_pod_phase
-                                
+
     processors:
       batch/metrics:
         timeout: 60s


### PR DESCRIPTION
- Migrate OpenTelemetryCollector from v1alpha1 to v1beta1 API
- Update collector image from v0.20.0 to v0.47.0 (fixes config compatibility)
- Convert config from inline string to structured YAML format
- Add otel-collector-prometheus.yaml to src/cdk/scripts/
- Use AWS_REGION and AMP_WORKSPACE_URL placeholders for deployment flexibility

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
