### PR TITLE
Fix CloudFormation template version

### DIFF
--- a/PetAdoptions/cdk/pet_stack/resources/use_cases/observability-getting-started-ADOT.yml
+++ b/PetAdoptions/cdk/pet_stack/resources/use_cases/observability-getting-started-ADOT.yml
@@ -23,7 +23,7 @@
 #
 #------------------------------------------------------------------------------
 ---
-AWSTemplateFormatVersion: '2023-10-10'
+AWSTemplateFormatVersion: '2010-09-09'
 Description: AWS CloudFormation template to launch an EC2 instance with required IAM permissions. Written for Observability getting started workshop Februray 2023. **WARNING** This template creates a VPC, public subnet, Internet Gateway, 1 EC2 with Apache installed, and associated route tables and permissions. You will be billed for the AWS resources used if you create a stack from this template.
 
 #-----------------------------------------------------------


### PR DESCRIPTION
*Description of changes:*

The AWSTemplateFormatVersion was set to an unexisting value: '2023-10-10', while the only valid value is '2010-09-09' (as per documentation https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html 
This prevents a successful deployment from an inexperienced user.
 
With this commit, the template version is fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
