### PR TITLE
Simplify footer by removing Amazon Q Developer

### DIFF
--- a/src/applications/microservices/petsite-net/petsite/Views/Shared/_Layout.cshtml
+++ b/src/applications/microservices/petsite-net/petsite/Views/Shared/_Layout.cshtml
@@ -109,8 +109,7 @@
             <div class="container">
                 <p class="mb-0" style="color: #6c757d; font-size: 0.9rem;">
                     Built with ❤️ in association with <a href="https://kiro.dev/" target="_blank"
-                        style="background: linear-gradient(135deg, #4A90E2 0%, #7B68EE 50%, #9B59B6 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; text-decoration: none; font-weight: 600;">Kiro</a> and <a href="https://aws.amazon.com/q/developer/" target="_blank"
-                        style="background: linear-gradient(135deg, #4A90E2 0%, #7B68EE 50%, #9B59B6 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; text-decoration: none; font-weight: 600;">Amazon Q Developer</a>
+                        style="background: linear-gradient(135deg, #4A90E2 0%, #7B68EE 50%, #9B59B6 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; text-decoration: none; font-weight: 600;">Kiro</a>
                 </p>
             </div>
         </footer>


### PR DESCRIPTION
Removed duplicate link to Amazon Q Developer in footer.

