### PR TITLE
docs: Update deployment documentation and default branch references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,45 @@ This repo contains a sample application which is used in the One Observability D
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
 
-## Instructions
+## Deployment Instructions
 
-To deploy this workshop on your own account you need to have an IAM role with elevated privileges and the `aws-cli` installed. Then, from the root
-of the repository run the following command:
+### Prerequisites
 
+- IAM role with elevated privileges
+- AWS CLI installed and configured
+- Appropriate AWS permissions for CloudFormation, CodeBuild, and related services
+
+### CloudFormation Templates
+
+This repository provides CloudFormation templates for automated deployment:
+
+- **[codebuild-deployment-template.yaml](./src/templates/codebuild-deployment-template.yaml)** - CodeBuild CDK deployment template with intelligent retry handling
+
+### Quick Start
+
+Deploy the workshop using the CodeBuild CDK deployment template:
+
+```bash
+aws cloudformation create-stack \
+  --stack-name OneObservability-Workshop-CDK \
+  --template-body file://src/templates/codebuild-deployment-template.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameters \
+    ParameterKey=pOrganizationName,ParameterValue=aws-samples \
+    ParameterKey=pRepositoryName,ParameterValue=one-observability-demo \
+    ParameterKey=pBranchName,ParameterValue=main \
+    ParameterKey=pWorkingFolder,ParameterValue=src/cdk
 ```
-aws cloudformation create-stack --stack-name Observability-Workshop --template-body file://codepipeline-stack.yaml --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=UserRoleArn,ParameterValue=$(aws iam get-role --role-name $(aws sts get-caller-identity --query Arn --output text | awk -F/ '{print $(NF-1)}') --query Role.Arn --output text)
-```
 
-You can replace the role specified in the parameter `UserRoleArn` with any other role with access to AWS CloudShell if you need so.
+For detailed parameter descriptions and advanced usage, refer to the [full documentation](./docs/codebuild-cdk-deployment-template.md).
+
+## Cleanup
+
+After completing the workshop, clean up your AWS resources to avoid ongoing charges.
+
+For comprehensive cleanup instructions, troubleshooting, and safety guidelines, see:
+
+**🧹 [Cleanup Script Documentation](./docs/CLEANUP_SCRIPT.md)**
 
 ## License
 

--- a/docs/codebuild-cdk-deployment-template.md
+++ b/docs/codebuild-cdk-deployment-template.md
@@ -124,7 +124,7 @@ flowchart TD
 
 ```bash
 aws cloudformation create-stack \
-  --stack-name MyWorkshop-CDK-Deployment \
+  --stack-name OneObservability-Workshop-CDK \
   --template-body file://codebuild-deployment-template.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameters \
@@ -138,14 +138,14 @@ aws cloudformation create-stack \
 
 ```bash
 aws cloudformation create-stack \
-  --stack-name MyWorkshop-CDK-Deployment \
+  --stack-name OneObservability-Workshop-CDK \
   --template-body file://codebuild-deployment-template.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameters \
     ParameterKey=pConfigFileUrl,ParameterValue=https://example.com/config.json \
     ParameterKey=pOrganizationName,ParameterValue=aws-samples \
     ParameterKey=pRepositoryName,ParameterValue=one-observability-demo \
-    ParameterKey=pBranchName,ParameterValue=feat/cdkpipeline \
+    ParameterKey=pBranchName,ParameterValue=main \
     ParameterKey=pWorkingFolder,ParameterValue=src/cdk \
     ParameterKey=pUserDefinedTagKey1,ParameterValue=Environment \
     ParameterKey=pUserDefinedTagValue1,ParameterValue=Workshop
@@ -155,10 +155,10 @@ aws cloudformation create-stack \
 
 | Parameter | Description | Default | Required |
 |-----------|-------------|---------|----------|
-| `pConfigFileUrl` | URL to the initial configuration file | `https://raw.githubusercontent.com/aws-samples/one-observability-demo/refs/heads/feat/cdkpipeline/src/presets/default.env` | Yes |
+| `pConfigFileUrl` | URL to the initial configuration file | `https://raw.githubusercontent.com/aws-samples/one-observability-demo/refs/heads/main/src/presets/default.env` | Yes |
 | `pOrganizationName` | GitHub/CodeCommit organization name | `aws-samples` | Yes |
 | `pRepositoryName` | Repository containing the CDK code | `one-observability-demo` | Yes |
-| `pBranchName` | Branch to deploy from | `feat/cdkpipeline` | Yes |
+| `pBranchName` | Branch to deploy from | `main` | Yes |
 | `pCodeConnectionArn` | Optional CodeConnection ARN for GitHub integration. If provided, will be used instead of S3 as pipeline source | `` (empty) | No |
 | `pWorkingFolder` | Working folder for deployment | `src/cdk` | Yes |
 | `pApplicationName` | Application name used for tagging deployed stacks | `One Observability Workshop` | Yes |

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -29,13 +29,13 @@ This documentation includes:
 
 ```bash
 aws cloudformation create-stack \
-  --stack-name MyWorkshop-CDK-Deployment \
+  --stack-name OneObservability-Workshop-CDK \
   --template-body file://codebuild-deployment-template.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameters \
     ParameterKey=pOrganizationName,ParameterValue=aws-samples \
     ParameterKey=pRepositoryName,ParameterValue=one-observability-demo \
-    ParameterKey=pBranchName,ParameterValue=feat/cdkpipeline \
+    ParameterKey=pBranchName,ParameterValue=main \
     ParameterKey=pWorkingFolder,ParameterValue=src/cdk
 ```
 

--- a/src/templates/codebuild-deployment-template.yaml
+++ b/src/templates/codebuild-deployment-template.yaml
@@ -65,7 +65,7 @@ Parameters:
     Description: URL to the initial configuration file
     AllowedPattern: ^https?://.*$
     ConstraintDescription: Must be a valid HTTP or HTTPS URL
-    Default: https://raw.githubusercontent.com/aws-samples/one-observability-demo/refs/heads/feat/cdkpipeline/src/presets/default.env
+    Default: https://raw.githubusercontent.com/aws-samples/one-observability-demo/refs/heads/main/src/presets/default.env
 
   pOrganizationName:
     Type: String
@@ -84,7 +84,7 @@ Parameters:
   pBranchName:
     Type: String
     Description: Branch to deploy from
-    Default: feat/cdkpipeline
+    Default: main
     AllowedPattern: '[A-Za-z0-9_./-]+'
     ConstraintDescription: Must contain only alphanumeric characters, underscores,
       periods, slashes, or hyphens


### PR DESCRIPTION
- Update README.md with comprehensive deployment instructions including prerequisites and quick start guide
- Add CloudFormation template deployment example with all required parameters
- Update codebuild-cdk-deployment-template.md to use main branch as default instead of feat/cdkpipeline
- Update src/templates/README.md with corrected stack name and branch references
- Update codebuild-deployment-template.yaml default parameter values to reference main branch
- Standardize stack naming convention across all documentation examples to OneObservability-Workshop-CDK
- Add reference to cleanup documentation in main README
- Consolidate deployment instructions for better clarity and user guidance

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
