### PR TITLE
fix(petfood-agent): Add bedrock:CountTokens permission to agent IAM policy

### DIFF
--- a/src/cdk/lib/microservices/petfood-agent.ts
+++ b/src/cdk/lib/microservices/petfood-agent.ts
@@ -80,7 +80,7 @@ export class PetFoodAgentConstruct extends Construct {
                 }),
                 new PolicyStatement({
                     effect: Effect.ALLOW,
-                    actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
+                    actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream', 'bedrock:CountTokens'],
                     resources: [
                         `arn:aws:bedrock:*::foundation-model/*`,
                         `arn:aws:bedrock:*:${Stack.of(this).account}:*`,


### PR DESCRIPTION
*Description of changes:*
- Add 'bedrock:CountTokens' action to the AgentCore IAM policy statement
- Allows the petfood-agent service to count tokens for Bedrock model invocations
- Completes the set of required Bedrock permissions for token management
