### PR TITLE
fix(docs): Correct technical inaccuracies in docs-site 

### DIFF
--- a/docs-site/docs/architecture/observability.md
+++ b/docs-site/docs/architecture/observability.md
@@ -8,15 +8,15 @@ Each microservice demonstrates a different observability instrumentation strateg
 
 | Service | Approach | Details |
 |---------|----------|---------|
-| `payforadoption-go` | OpenTelemetry Go SDK | ADOT collector sidecar |
+| `payforadoption-go` | OpenTelemetry Go SDK | CloudWatch agent sidecar (OTLP mode) |
 | `petlistadoptions-py` | ADOT auto-instrumentation | CloudWatch agent sidecar (manual config for FastAPI) |
 | `petsearch-java` | Application Signals | L2 construct with auto + manual instrumentation, SLO definitions |
-| `petsite-net` | CloudWatch agent | Application Signals on EKS |
+| `petsite-net` | CloudWatch agent | Application Signals on EKS (managed node group) |
 | `petfood-rs` | OpenTelemetry Rust SDK | Custom Prometheus metrics |
 
 ## Log Routing
 
-- **FireLens** (Fluent Bit) sidecar on ECS tasks routes logs to CloudWatch Logs
+- **FireLens** (Fluent Bit) sidecar on ECS tasks routes logs to OpenSearch (optional, requires `ENABLE_OPENSEARCH=true`)
 - **Container Insights** on ECS and EKS clusters for infrastructure metrics
 - **OpenSearch** ingestion pipeline for centralized log analytics
 
@@ -30,7 +30,7 @@ Each microservice demonstrates a different observability instrumentation strateg
 
 ### payforadoption-go
 
-Uses the OpenTelemetry Go SDK with an ADOT collector sidecar container. Traces are exported via OTLP to the collector, which forwards them to X-Ray. This demonstrates manual SDK instrumentation in Go.
+Uses the OpenTelemetry Go SDK with a CloudWatch agent sidecar in OTLP mode. Traces are exported via OTLP to the agent, which forwards them to X-Ray. This demonstrates manual SDK instrumentation in Go with custom SQL span processing for Aurora correlation.
 
 ### petlistadoptions-py
 

--- a/docs-site/docs/architecture/overview.md
+++ b/docs-site/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-The One Observability Demo is deployed using AWS CDK with a multi-stage pipeline architecture. The infrastructure is organized into five deployment stages across two waves, plus a standalone microservices stage.
+The One Observability Demo is deployed using AWS CDK with a multi-stage pipeline architecture. The infrastructure is organized into five deployment stages: two waves of two stages each, followed by a standalone Microservices stage.
 
 ## CDK Pipeline Architecture
 

--- a/docs-site/docs/architecture/stages.md
+++ b/docs-site/docs/architecture/stages.md
@@ -5,11 +5,11 @@
 Deploys foundational infrastructure required by all other stages.
 
 - VPC with public/private subnets, NAT gateways
-- VPC Endpoints for private AWS service connectivity (SSM, ECR, CloudWatch, X-Ray, STS, EventBridge, S3, DynamoDB)
+- VPC Endpoints for private AWS service connectivity (SSM, SSM Messages, EC2 Messages, Secrets Manager, CloudWatch Logs, CloudWatch Monitoring, Lambda, API Gateway, Cloud Map, S3, DynamoDB)
 - Security groups and IAM roles
 - CloudTrail audit logging
 - EventBridge event bus
-- OpenSearch Serverless collection and ingestion pipeline
+- Amazon SQS queue with dead-letter queue for async messaging
 
 ![Core Stage Resources](../assets/diagrams/core-stage-resources.png)
 
@@ -35,7 +35,6 @@ Deploys data persistence and messaging resources.
 - **Amazon DynamoDB** — Pet adoption, pet foods, and pet foods cart tables
 - **Amazon Aurora PostgreSQL** — Relational database for structured data
 - **Amazon S3** — Workshop assets bucket with pet images, CloudFront CDN
-- **Amazon SQS** — Message queue for decoupled communication
 
 Post-deployment steps: DynamoDB seeding and RDS seeding run as CodeBuild steps.
 
@@ -43,12 +42,13 @@ Post-deployment steps: DynamoDB seeding and RDS seeding run as CodeBuild steps.
 
 ## 4. Compute Stage
 
-Deploys container orchestration platforms.
+Deploys container orchestration platforms and optional search infrastructure.
 
 - **Amazon ECS** — Fargate cluster for microservice tasks
-- **Amazon EKS** — Kubernetes cluster with managed node groups
+- **Amazon EKS** — Kubernetes cluster with managed node groups (EC2)
 - **Application Load Balancers** — Traffic distribution for ECS and EKS
 - **Container Insights** — Enabled on both clusters
+- **OpenSearch Serverless** — Collection, ingestion pipeline, and application (optional, requires `ENABLE_OPENSEARCH=true`)
 
 ![Compute Stage Resources](../assets/diagrams/compute-stage-resources-corrected.png)
 
@@ -62,7 +62,7 @@ Deploys all microservices, serverless functions, canaries, and WAF rules.
 ### Microservices
 
 - 4 ECS services: payforadoption-go, petlistadoptions-py, petsearch-java, petfood-rs
-- 1 EKS deployment: petsite-net (with CloudFront distribution and WAF)
+- 1 EKS deployment: petsite-net (with CloudFront distribution)
 - 1 Bedrock AgentCore deployment: petfoodagent-strands-py
 
 ### Lambda Functions
@@ -70,31 +70,36 @@ Deploys all microservices, serverless functions, canaries, and WAF rules.
 | Function | Runtime | Purpose |
 |----------|---------|---------|
 | StatusUpdater | Node.js | Updates pet adoption status in DynamoDB |
-| UserCreator | Node.js | Creates Cognito users |
-| RdsSeeder | Node.js | Seeds Aurora PostgreSQL |
+| UserCreator | Python | Creates user records in Aurora PostgreSQL |
+| RdsSeeder | Python | Seeds Aurora PostgreSQL |
 | TrafficGenerator | Node.js | Generates synthetic traffic |
 | PetfoodStockProcessor | Node.js | Processes food stock events from EventBridge |
-| PetfoodImageGenerator | Node.js | Generates pet food images via Bedrock |
+| PetfoodImageGenerator | Python | Generates pet food images via Bedrock |
 | PetfoodCleanupProcessor | Node.js | Cleans up expired food listings |
+| DynamoCapacityTest | Python | DynamoDB write capacity testing |
 
 ### Canaries
 
 - **TrafficGeneratorCanary** — CloudWatch Synthetics canary for continuous traffic
 - **HousekeepingCanary** — Periodic cleanup of stale resources
 
-### WAF
+### WAF (optional)
 
-- Regional WAF on ALB
-- Global WAF on CloudFront (optional, controlled by feature flag)
+- Regional WAF on ALB (requires `CUSTOM_ENABLE_WAF=true`)
+- Global WAF on CloudFront (requires `CUSTOM_ENABLE_WAF=true`)
 
 ## Stage Dependencies
 
 ```mermaid
 flowchart TD
-    Core["Core Stage"] --> Containers["Containers Stage"]
-    Core --> Storage["Storage Stage"]
-    Core --> Compute["Compute Stage"]
-    Containers --> Microservices["Microservices Stage"]
-    Storage --> Microservices
-    Compute --> Microservices
+    subgraph CoreWave["Core Wave (parallel)"]
+        Core["Core Stage"]
+        Containers["Containers Stage"]
+    end
+    subgraph BackendWave["Backend Wave (parallel)"]
+        Storage["Storage Stage"]
+        Compute["Compute Stage"]
+    end
+    CoreWave --> BackendWave
+    BackendWave --> Microservices["Microservices Stage"]
 ```

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -47,7 +47,7 @@ The One Observability Demo deploys a pet adoption store with these components:
 | `payforadoption-go` | Go | ECS Fargate | OpenTelemetry Go SDK |
 | `petlistadoptions-py` | Python/FastAPI | ECS Fargate | ADOT auto-instrumentation |
 | `petsearch-java` | Java/Spring Boot | ECS Fargate | Application Signals |
-| `petsite-net` | .NET | EKS Fargate | CloudWatch agent |
+| `petsite-net` | .NET | EKS | CloudWatch agent |
 | `petfood-rs` | Rust/Axum | ECS Fargate | OpenTelemetry Rust SDK |
 | `petfoodagent-strands-py` | Python/Strands | Bedrock AgentCore | AI agent instrumentation |
 

--- a/docs-site/docs/microservices/index.md
+++ b/docs-site/docs/microservices/index.md
@@ -16,19 +16,20 @@ flowchart TD
     EB --> StockProcessor["Stock Processor λ"]
     EB --> ImageGen["Image Generator λ"]
     PetList --> Aurora["Aurora PostgreSQL"]
+    PayFor --> Aurora
     PayFor --> DynamoDB["DynamoDB"]
     PetFood --> DynamoDB
-    PetSearch --> Aurora
+    PetSearch --> DynamoDB
 ```
 
 ## Services at a Glance
 
 | Service | Language | Platform | Observability | Description |
 |---------|----------|----------|---------------|-------------|
-| [`payforadoption-go`](payforadoption-go.md) | Go | ECS Fargate | OTel Go SDK + ADOT sidecar | Payment processing |
+| [`payforadoption-go`](payforadoption-go.md) | Go | ECS Fargate | OTel Go SDK + CloudWatch agent | Payment processing |
 | [`petsearch-java`](petsearch-java.md) | Java/Spring Boot | ECS Fargate | Application Signals | Pet search |
 | [`petlistadoptions-py`](petlistadoptions-py.md) | Python/FastAPI | ECS Fargate | ADOT auto-instrumentation | Pet listing and adoptions |
-| [`petsite-net`](petsite-net.md) | .NET | EKS Fargate | CloudWatch agent | Web frontend |
+| [`petsite-net`](petsite-net.md) | .NET | EKS | CloudWatch agent | Web frontend |
 | [`petfood-rs`](petfood-rs.md) | Rust/Axum | ECS Fargate | OTel Rust SDK + Prometheus | Food catalog and cart |
 | [`petfoodagent-strands-py`](petfoodagent-strands-py.md) | Python/Strands | Bedrock AgentCore | AI agent | Food recommendations |
 

--- a/docs-site/docs/microservices/payforadoption-go.md
+++ b/docs-site/docs/microservices/payforadoption-go.md
@@ -10,16 +10,16 @@ Payment processing service written in Go, deployed on ECS Fargate.
 | Platform | ECS Fargate |
 | Architecture | AMD64 |
 | Observability | OpenTelemetry Go SDK |
-| Data Store | DynamoDB |
+| Data Store | Aurora PostgreSQL + DynamoDB |
 
 ## Observability
 
-Uses the **OpenTelemetry Go SDK** with an ADOT collector sidecar container:
+Uses the **OpenTelemetry Go SDK** with a CloudWatch agent sidecar in OTLP mode:
 
-- Traces exported via OTLP to the ADOT collector sidecar
-- Collector forwards traces to AWS X-Ray
+- Traces exported via OTLP to the CloudWatch agent sidecar
+- Agent forwards traces to AWS X-Ray
 - Demonstrates manual SDK instrumentation in Go
-- FireLens (Fluent Bit) sidecar routes logs to CloudWatch Logs
+- Custom SQL span processor for Aurora database correlation
 
 ## Source
 

--- a/docs-site/docs/microservices/petsearch-java.md
+++ b/docs-site/docs/microservices/petsearch-java.md
@@ -10,7 +10,7 @@ Pet search service written in Java/Spring Boot, deployed on ECS Fargate.
 | Platform | ECS Fargate |
 | Architecture | AMD64 |
 | Observability | Application Signals |
-| Data Store | Aurora PostgreSQL |
+| Data Store | DynamoDB |
 
 ## Observability
 

--- a/docs-site/docs/microservices/petsite-net.md
+++ b/docs-site/docs/microservices/petsite-net.md
@@ -1,17 +1,17 @@
 # petsite-net
 
-Web frontend written in .NET, deployed on EKS Fargate.
+Web frontend written in .NET, deployed on EKS with managed node groups.
 
 ## Overview
 
 | Property | Value |
 |----------|-------|
 | Language | .NET |
-| Platform | EKS Fargate |
+| Platform | EKS (managed node group) |
 | Architecture | AMD64 |
 | Observability | CloudWatch agent |
 | CDN | CloudFront |
-| Security | Regional + Global WAF |
+| Security | Regional + Global WAF (optional, feature-flagged) |
 
 ## Observability
 

--- a/docs-site/docs/operations/image-generation.md
+++ b/docs-site/docs/operations/image-generation.md
@@ -1,11 +1,11 @@
 # Image Generation
 
-The image generation system creates pet and food images using Amazon Bedrock Titan Image Generator v2.
+The image generation system creates pet and food images using Amazon Nova Canvas v1.
 
 ## Prerequisites
 
 - AWS CLI v2 with Bedrock support
-- Bedrock model access enabled for **Amazon Titan Image Generator G1 v2**
+- Bedrock model access enabled for **Amazon Nova Canvas v1**
 - `jq` installed
 
 ## Usage
@@ -47,7 +47,7 @@ Images are deployed via CDK:
 ## Model Access Setup
 
 1. Go to [AWS Bedrock Console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess)
-2. Enable access for **Amazon Titan Image Generator G1 v2**
+2. Enable access for **Amazon Nova Canvas v1**
 3. Wait for approval (typically instant)
 
 ## Features


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- EKS platform: "EKS Fargate" → "EKS (managed node group)" — no Fargate profiles exist
- Data stores: petsearch-java uses DynamoDB (not Aurora), payforadoption-go uses both
- Observability: payforadoption-go uses CloudWatch agent sidecar (not ADOT collector)
- Lambda runtimes: UserCreator, RdsSeeder, PetfoodImageGenerator are Python (not Node.js)
- Stage placement: OpenSearch in Compute Stage, SQS in Core Stage
- VPC endpoints: corrected list to match actual deployed endpoints
- WAF: marked as optional (requires CUSTOM_ENABLE_WAF=true)
- Stage diagram: Core and Containers are parallel (same wave), not sequential
- Image generation: model is Amazon Nova Canvas v1 (not Titan)
- FireLens: routes to OpenSearch (not CloudWatch Logs), optional
- UserCreator: creates PostgreSQL records (not Cognito users)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
