### PR TITLE
Fix undefined processor reference in ECS metrics pipeline

### DIFF
--- a/src/cdk/scripts/build-otel-ecr.sh
+++ b/src/cdk/scripts/build-otel-ecr.sh
@@ -91,7 +91,7 @@ service:
     # ECS container metrics pipeline
     metrics/ecs:
       receivers: [awsecscontainermetrics]
-      processors: [resource]
+      processors: [batch/metrics]
       exporters: [prometheusremotewrite, debug]
 EOF
 


### PR DESCRIPTION
The build-otel-ecr.sh script referenced a processor named 'resource' in the metrics/ecs pipeline, but only 'resourcedetection' and 'batch/metrics' are defined in the processors section. This caused the OTel collector to fail on startup with:

Error: invalid configuration: service::pipelines::metrics/ecs: references processor "resource" which is not configured

Changed to 'batch/metrics' which is defined and matches the workshop documentation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
