### PR TITLE
fix: Exempt workshop resources from SpringClean stop cycle

### DIFF
--- a/src/cdk/bin/environment.ts
+++ b/src/cdk/bin/environment.ts
@@ -89,6 +89,15 @@ export const TAGS = {
     environment: 'non-prod',
     application: 'One Observability Workshop',
     stackName: process.env.STACK_NAME || 'MissingStackName',
+    /**
+     * Exempts all workshop resources from AWS SpringClean's daily stop cycle.
+     * Without this, SpringClean scales EC2/ASG-backed resources (e.g. the EKS
+     * managed nodegroup's Auto Scaling Group) to zero at shift end, taking down
+     * the EKS-hosted PetSite frontend outside business hours. This only
+     * controls the *stop* action; deletion is separately governed by the
+     * `auto-delete` tag applied at the top-level CloudFormation stack.
+     */
+    'auto-stop': 'no',
 };
 
 /** Default retention period for logs */


### PR DESCRIPTION
## Summary

Adds `auto-stop: no` to the shared `TAGS` constant in `src/cdk/bin/environment.ts`, which propagates via `Utilities.TagConstruct` (CDK Tags aspect) to every resource in every stack — including the EKS managed nodegroup's underlying Auto Scaling Group.

## Root cause

The account has a pre-existing, account-wide cost-optimization tool (AWS SpringClean) that stops EC2/ASG-backed resources outside configured business hours unless they carry an `auto-stop: no` tag. This is a *separate* control from `auto-delete`, which only governs deletion after a retention period.

Confirmed via CloudTrail:
```
SpringClean-XUG3HH5R-SpringCleanLambda called autoscaling:UpdateAutoScalingGroup
(minSize=0, desiredCapacity=0) on the EKS nodegroup ASG at shift end.
```

**Impact chain:**
1. EKS nodegroup ASG scaled to 0 → both worker nodes terminated
2. All EKS pods (petsite-frontend-dotnet, CoreDNS, ALB controller) went `Pending` — no nodes to schedule on
3. ALB target group `TG-petsite-net` had both targets go `unhealthy` (`Target.Timeout`)
4. CloudFront origin (the ALB) had no healthy backend → `504 Gateway Timeout`

ECS Fargate services (petsearch-java, petfood-rs, payforadoption-go, petlistadoption-py) were unaffected — SpringClean's stop capability covers EC2/ASG/RDS but not ECS Fargate services.

## Testing

- `npx tsc --noEmit` — passes
- `npm run build` — passes
- `npm run test` (jest) — 1/1 passing
- Verified live: manually applied the same tag to the running ASG, scaled the nodegroup back up, confirmed EKS nodes rejoined, ALB targets went healthy, and the PetSite CloudFront URL returned HTTP 200 again.

This code change ensures the fix persists across pipeline redeployments, since CloudFormation reconciles the ASG's tag set on every stack update and would otherwise wipe a manually-applied CLI tag.