### PR TITLE
feat(petfoodagent): Upgrade to Claude Sonnet 5 + capture full prompts in span attributes

### DIFF
--- a/src/applications/microservices/petfoodagent-strands-py/agent.py
+++ b/src/applications/microservices/petfoodagent-strands-py/agent.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 PARAMETER_STORE_PREFIX = os.environ.get("PARAMETER_STORE_PREFIX")
 if not PARAMETER_STORE_PREFIX:
     raise RuntimeError("Required environment variable PARAMETER_STORE_PREFIX not set")
-MODEL_ID = "us.anthropic.claude-sonnet-4-6"
+MODEL_ID = "us.anthropic.claude-sonnet-5"
 
 # Initialize SSM client
 REGION = os.environ.get("AWS_REGION", "us-east-1")

--- a/src/applications/microservices/petfoodagent-strands-py/requirements.txt
+++ b/src/applications/microservices/petfoodagent-strands-py/requirements.txt
@@ -1,5 +1,5 @@
 bedrock-agentcore
 strands-agents[otel]
 strands-agents-tools
-aws-opentelemetry-distro>=0.10.0
+aws-opentelemetry-distro>=0.18.0
 boto3

--- a/src/cdk/lib/microservices/petfood-agent.ts
+++ b/src/cdk/lib/microservices/petfood-agent.ts
@@ -174,6 +174,8 @@ export class PetFoodAgentConstruct extends Construct {
                 AWS_REGION: Stack.of(this).region,
                 SEARCH_API_URL_PARAMETER_NAME: SSM_PARAMETER_NAMES.SEARCH_API_URL,
                 PETFOOD_API_URL_PARAMETER_NAME: SSM_PARAMETER_NAMES.FOOD_API_URL,
+                AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT: 'true',
+                AGENT_OBSERVABILITY_ENABLED: 'true',
             },
             protocolConfiguration: 'HTTP',
         });


### PR DESCRIPTION
*Description of changes:*
Upgrades the PetFood agent to **Claude Sonnet 5** and sets
`AWS_GENAI_CONTENT_EXTRACTION_OPT_OUT=true` so prompts are captured whole
(not split) and recorded as span attributes for GenAI observability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
