### PR TITLE
fix(petsite-UI): Resolve theme conflicts and improve component styling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -201,22 +201,6 @@
         "line_number": 217
       }
     ],
-    "src/applications/microservices/petsite-net/petsite/Views/Adoption/Index.cshtml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/applications/microservices/petsite-net/petsite/Views/Adoption/Index.cshtml",
-        "hashed_secret": "61f66022ecc0cdfa182825047ff2da0e8bdce581",
-        "is_verified": false,
-        "line_number": 7
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/applications/microservices/petsite-net/petsite/Views/Adoption/Index.cshtml",
-        "hashed_secret": "2bd221d058dee45f9c9a1932f5e01e66c13bd432",
-        "is_verified": false,
-        "line_number": 8
-      }
-    ],
     "src/applications/microservices/petsite-net/petsite/wwwroot/lib/jquery-validation/dist/additional-methods.js": [
       {
         "type": "Base64 High Entropy String",
@@ -250,5 +234,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-28T22:46:23Z"
+  "generated_at": "2026-08-21T22:01:25Z"
 }

--- a/src/applications/microservices/petsite-net/petsite/Views/Adoption/Index.cshtml
+++ b/src/applications/microservices/petsite-net/petsite/Views/Adoption/Index.cshtml
@@ -4,9 +4,8 @@
     @model Pet;
 }
 
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
-<script src="//code.jquery.com/jquery-3.6.0.min.js"></script>
+@* Bootstrap and jQuery come from _Layout. A CDN copy here would load after
+   petsite-modern.css and take the payment card back to the light theme. *@
 
 <section class="pet-hero">
     <div class="container">

--- a/src/applications/microservices/petsite-net/petsite/Views/Checkout/Index.cshtml
+++ b/src/applications/microservices/petsite-net/petsite/Views/Checkout/Index.cshtml
@@ -130,7 +130,9 @@
                             </div>
                         </div>
 
-                        <button id="payCheckoutBtn" class="btn btn-primary btn-lg btn-block w-100">Pay and Checkout</button>
+                        @* btn-success to match "Pay and Adopt"; btn-primary resolved to the
+                           near-black / near-white pill that flipped with the theme *@
+                        <button id="payCheckoutBtn" class="btn btn-success btn-lg btn-block w-100">Pay and Checkout</button>
                         <div id="success-message" class="alert alert-success mt-3" style="display: none;">Thank you for your order!</div>
                     </div>
                 </div>

--- a/src/applications/microservices/petsite-net/petsite/Views/Payment/Index.cshtml
+++ b/src/applications/microservices/petsite-net/petsite/Views/Payment/Index.cshtml
@@ -41,11 +41,14 @@
                   </div>
                 }
               </div>
-              <div style="display: flex; gap: 10px; margin-top: 15px;">
-                <a asp-controller="FoodService" asp-action="Index" asp-route-userId="@ViewBag.UserId" asp-route-petType="@pet.pettype" asp-route-petId="@pet.petid" class="btn btn-primary btn-lg">
+              @* the two next steps get their own hues: amber for the shop, Waggle teal for the assistant *@
+              <div class="ps-nextrow">
+                <a asp-controller="FoodService" asp-action="Index" asp-route-userId="@ViewBag.UserId" asp-route-petType="@pet.pettype" asp-route-petId="@pet.petid" class="ps-next ps-next-food">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 7V6a6 6 0 0 1 12 0v1h3l-1.2 13.1A2 2 0 0 1 17.8 22H6.2a2 2 0 0 1-2-1.9L3 7h3Zm2 0h8V6a4 4 0 0 0-8 0v1Z"/></svg>
                   Buy food for me
                 </a>
-                <a asp-controller="Waggle" asp-action="Index" asp-route-userId="@ViewBag.UserId" class="btn btn-info btn-lg">
+                <a asp-controller="Waggle" asp-action="Index" asp-route-userId="@ViewBag.UserId" class="ps-next ps-next-waggle">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3c5.1 0 9 3.4 9 7.8s-3.9 7.8-9 7.8c-1 0-2-.1-3-.4-1 .7-2.5 1.5-4.4 1.7 1-1.1 1.4-2.4 1.5-3.4-1.9-1.4-3.1-3.4-3.1-5.7C3 6.4 6.9 3 12 3Z"/></svg>
                   Chat with Waggle AI
                 </a>
               </div>

--- a/src/applications/microservices/petsite-net/petsite/wwwroot/css/petsite-modern.css
+++ b/src/applications/microservices/petsite-net/petsite/wwwroot/css/petsite-modern.css
@@ -18,6 +18,10 @@
     --ps-cta-to: #0D9488;
     --ps-cta-ink: #ffffff;
     --ps-cta-glow: rgba(13, 148, 136, .28);
+    --ps-food-from: #FB923C;
+    --ps-food-to: #EA580C;
+    --ps-food-ink: #ffffff;
+    --ps-food-glow: rgba(234, 88, 12, .30);
     --ps-r-lg: 22px;
     --ps-r-md: 14px;
     --ps-shadow: 0 1px 2px rgba(15, 27, 42, .05), 0 8px 24px rgba(15, 27, 42, .06);
@@ -43,6 +47,10 @@
     --ps-cta-to: #0B7268;
     --ps-cta-ink: #ffffff;
     --ps-cta-glow: rgba(0, 0, 0, .45);
+    /* deeper amber so white ink keeps AA against the darker page */
+    --ps-food-from: #F97316;
+    --ps-food-to: #C2410C;
+    --ps-food-glow: rgba(0, 0, 0, .45);
 }
 
 html, body {
@@ -368,6 +376,15 @@ select.pet-filter:focus-visible, .ps-select:focus-visible {
     border-radius: var(--ps-r-md);
 }
 
+/* the demo payment fields are all readonly; Bootstrap's own grey fill made the
+   card look light-mode and swallowed the values */
+.form-control[readonly], .form-control:disabled,
+.form-select[readonly], .form-select:disabled {
+    background-color: var(--ps-surface);
+    color: var(--ps-ink);
+    opacity: 1;
+}
+
 .form-control:focus, .form-select:focus {
     background: var(--ps-canvas); border-color: var(--ps-teal); color: var(--ps-ink);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--ps-teal) 22%, transparent);
@@ -377,6 +394,41 @@ select.pet-filter:focus-visible, .ps-select:focus-visible {
 .text-muted, .form-text, small.text-muted { color: var(--ps-muted) !important; }
 
 .alert { border-radius: var(--ps-r-md); border: 1px solid var(--ps-hairline); }
+
+/* Bootstrap's dark tints are near-black fills with dim ink, so a banner like
+   "Adoption Complete" reads as a muddy rectangle. Rebuild them as a tinted
+   surface with full-strength body text. */
+[data-theme="dark"] .alert {
+    background: var(--ps-surface);
+    border-color: var(--ps-hairline);
+    color: var(--ps-ink);
+    box-shadow: var(--ps-shadow);
+}
+
+[data-theme="dark"] .alert hr { border-top-color: var(--ps-hairline); opacity: 1; }
+[data-theme="dark"] .alert .alert-heading { color: var(--ps-ink); }
+
+[data-theme="dark"] .alert-success {
+    background: color-mix(in srgb, var(--ps-teal) 12%, var(--ps-surface));
+    border-color: color-mix(in srgb, var(--ps-teal) 28%, var(--ps-hairline));
+}
+
+[data-theme="dark"] .alert-success .alert-heading { color: var(--ps-teal-2); }
+
+/* amber needs a heavier mix than teal to read as amber rather than brown */
+[data-theme="dark"] .alert-warning {
+    background: color-mix(in srgb, var(--ps-accent) 24%, var(--ps-surface));
+    border-color: color-mix(in srgb, var(--ps-accent) 50%, var(--ps-hairline));
+}
+
+[data-theme="dark"] .alert-warning .alert-heading { color: var(--ps-accent); }
+
+[data-theme="dark"] .alert-danger {
+    background: color-mix(in srgb, var(--ps-danger) 14%, var(--ps-surface));
+    border-color: color-mix(in srgb, var(--ps-danger) 30%, var(--ps-hairline));
+}
+
+[data-theme="dark"] .alert-danger .alert-heading { color: #FCA5A5; }
 
 /* radio and checkbox glyphs need a visible tint on dark */
 [data-theme="dark"] input[type="radio"],
@@ -405,6 +457,39 @@ select.pet-filter:focus-visible, .ps-select:focus-visible {
 
 /* the page headings were inline styled bright green */
 h2[style], h3[style], .food-heading { color: var(--ps-ink) !important; }
+
+/* ---------------- after the adoption: the two next steps ---------------- */
+
+/* these were btn-primary / btn-info, which resolve to the near-black and near-white
+   pill pair; a hue each reads as a choice rather than a default */
+.ps-nextrow { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 16px; }
+
+.ps-next {
+    display: inline-flex; align-items: center; gap: 9px; border: none;
+    border-radius: 999px; padding: 12px 22px; text-decoration: none; cursor: pointer;
+    font-family: 'Nunito Sans', sans-serif; font-weight: 800; font-size: 15px;
+    transition: transform .16s ease, box-shadow .16s ease, filter .16s ease;
+}
+
+.ps-next:hover { transform: translateY(-2px); filter: brightness(1.05); text-decoration: none; }
+.ps-next svg { width: 17px; height: 17px; flex: none; fill: currentColor; }
+.ps-next:focus-visible { outline: 2px solid var(--ps-ink); outline-offset: 3px; }
+
+.ps-next-food, .ps-next-food:hover {
+    background: linear-gradient(180deg, var(--ps-food-from), var(--ps-food-to));
+    color: var(--ps-food-ink);
+}
+
+.ps-next-food { box-shadow: 0 4px 14px var(--ps-food-glow); }
+.ps-next-food:hover { box-shadow: 0 9px 22px var(--ps-food-glow); }
+
+.ps-next-waggle, .ps-next-waggle:hover {
+    background: linear-gradient(180deg, var(--ps-cta-from), var(--ps-cta-to));
+    color: var(--ps-cta-ink);
+}
+
+.ps-next-waggle { box-shadow: 0 4px 14px var(--ps-cta-glow); }
+.ps-next-waggle:hover { box-shadow: 0 9px 22px var(--ps-cta-glow); }
 
 /* ---------------- adoption list ---------------- */
 
@@ -442,7 +527,7 @@ h2[style], h3[style], .food-heading { color: var(--ps-ink) !important; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .ps-topbar, .ps-card, .pet-button, .ps-adopt, .ps-icon, #searchpets, .ps-btn {
+    .ps-topbar, .ps-card, .pet-button, .ps-adopt, .ps-icon, #searchpets, .ps-btn, .ps-next {
         transition: none !important;
     }
 }

--- a/src/applications/microservices/petsite-net/petsite/wwwroot/js/petsite-ui.js
+++ b/src/applications/microservices/petsite-net/petsite/wwwroot/js/petsite-ui.js
@@ -8,6 +8,9 @@
 
     function apply(theme) {
         document.documentElement.setAttribute('data-theme', theme);
+        // Bootstrap 5.3 keys its own semantic colours (alerts, badges, tables) off
+        // data-bs-theme; without this they stay light and vanish on a dark page.
+        document.documentElement.setAttribute('data-bs-theme', theme);
         var icon = document.getElementById('ps-theme-icon');
         if (icon) {
             icon.innerHTML = theme === 'dark'


### PR DESCRIPTION
*Description of changes:*
- Remove duplicate Bootstrap and jQuery CDN links from Adoption view that conflicted with _Layout includes and caused theme regression
- Change checkout button from btn-primary to btn-success to match "Pay and Adopt" styling and prevent theme flip
- Replace inline flex layout with ps-nextrow class and add SVG icons to payment flow buttons (food shop, Waggle chat)
- Add food shop button styling with amber gradient (ps-next-food) and Waggle button with teal gradient (ps-next-waggle)
- Define new CSS variables for food button theme: --ps-food-from, --ps-food-to, --ps-food-ink, --ps-food-glow in both light and dark modes
- Fix readonly/disabled form control styling to use ps-surface background instead of Bootstrap's grey, improving readability in dark mode
- Rebuild Bootstrap alert component styling for dark mode with proper contrast and tinted backgrounds instead of muddy near-black fills
- Apply color-mix for alert variants (success, warning, danger) with appropriate heading colors for dark theme



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
