### PR TITLE
fix(waggle-ai): Correct Application Signals dependency map and re-ingest KB when corpus changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "one-observability-workshop",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "one-observability-workshop",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "dependencies": {
                 "eslint": "^9.33.0",
                 "npm-check-updates": "^18.0.2"

--- a/src/applications/microservices/waggle_ai_agents/orchestrator_strands/delegate.py
+++ b/src/applications/microservices/waggle_ai_agents/orchestrator_strands/delegate.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import contextmanager
+from typing import Any, Iterator
 
 from waggle_ai_agents.common import config
 
@@ -16,6 +18,30 @@ _TARGETS = {
     "adoption": os.getenv("ADOPTION_TARGET", "adoption"),
     "concierge": os.getenv("CONCIERGE_TARGET", "concierge"),
 }
+
+# logical agent -> Application Signals service name of the sub-agent runtime.
+# Must match the node the sub-agent's own telemetry reports, which is its
+# AgentCore runtime name plus the qualifier (see WAGGLE_AI_AGENT_RUNTIMES in
+# cdk/lib/stages/applications.ts); a mismatch adds a node instead of an edge.
+_SERVICE_NAMES = {
+    "nutrition": os.getenv("NUTRITION_SERVICE", "WaggleAINutrition.DEFAULT"),
+    "ordering": os.getenv("ORDERING_SERVICE", "WaggleAIOrdering.DEFAULT"),
+    "adoption": os.getenv("ADOPTION_SERVICE", "WaggleAIAdoption.DEFAULT"),
+    "concierge": os.getenv("CONCIERGE_SERVICE", "WaggleAIConcierge.DEFAULT"),
+}
+
+# Environment half of the dimension pair. Every AgentCore runtime reports this.
+_REMOTE_ENVIRONMENT = os.getenv("AGENT_REMOTE_ENVIRONMENT", "bedrock-agentcore:default")
+
+try:
+    from opentelemetry import trace as _otel
+    from opentelemetry.trace import SpanKind, Status, StatusCode
+
+    _TRACER = _otel.get_tracer("waggle_ai_agents.delegate")
+except (
+    ImportError
+):  # OTel ships with the runtime image only; local dev works without it
+    _TRACER = None
 
 
 def delegate(agent: str, query: str, user_id: str | None = None) -> str:
@@ -38,6 +64,39 @@ def _in_process(agent: str, query: str, user_id: str | None) -> str:
     else:
         raise ValueError(f"unknown agent '{agent}'")
     return run(query, user_id=user_id)
+
+
+@contextmanager
+def _delegation_span(agent: str, url: str) -> Iterator[Any]:
+    """CLIENT span naming the sub-agent as the remote service.
+
+    Application Signals keys a map edge on the RemoteService/RemoteEnvironment
+    dimension pair, which it takes from these attributes. Without them the only
+    CLIENT span for this hop is the auto-instrumented HTTP one, whose remote
+    service is the gateway hostname -- a dead-end node, since the gateway emits
+    no server span of its own. The EKS services solve the same problem with
+    CloudWatch agent dimension replacement (cdk/lib/constructs/eks.ts), but
+    AgentCore Runtime is managed and runs no CloudWatch agent, so the
+    orchestrator has to set the attributes itself.
+
+    Yields None when OpenTelemetry is absent so local runs still work.
+    """
+    if _TRACER is None:
+        yield None
+        return
+    with _TRACER.start_as_current_span(
+        f"POST /{_TARGETS[agent]}/invocations",
+        kind=SpanKind.CLIENT,
+        attributes={
+            "aws.remote.service": _SERVICE_NAMES[agent],
+            "aws.remote.environment": _REMOTE_ENVIRONMENT,
+            "aws.remote.operation": "POST /invocations",
+            # Keep the real network hop visible for trace drill-down.
+            "url.full": url,
+            "http.request.method": "POST",
+        },
+    ) as span:
+        yield span
 
 
 def _via_gateway(agent: str, query: str, user_id: str | None) -> str:
@@ -65,12 +124,23 @@ def _via_gateway(agent: str, query: str, user_id: str | None) -> str:
         "bedrock-agentcore",
         config.AWS_REGION,
     ).add_auth(signed)
-    try:
-        resp = httpx.post(url, content=body, headers=dict(signed.headers), timeout=120)
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as exc:  # noqa: BLE001 - surface to the orchestrator
-        return json.dumps({"error": f"gateway call to '{agent}' failed: {exc}"})
+    with _delegation_span(agent, url) as span:
+        try:
+            resp = httpx.post(
+                url,
+                content=body,
+                headers=dict(signed.headers),
+                timeout=120,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001 - surface to the orchestrator
+            if span is not None:
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+            return json.dumps({"error": f"gateway call to '{agent}' failed: {exc}"})
+        if span is not None:
+            span.set_attribute("http.response.status_code", resp.status_code)
     if isinstance(data, dict):
         return data.get("output") or data.get("result") or json.dumps(data)
     return str(data)

--- a/src/applications/microservices/waggle_ai_agents/orchestrator_strands/delegate.py
+++ b/src/applications/microservices/waggle_ai_agents/orchestrator_strands/delegate.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Iterator
+from typing import Any
 
 from waggle_ai_agents.common import config
 

--- a/src/cdk/lib/constructs/eks.ts
+++ b/src/cdk/lib/constructs/eks.ts
@@ -222,6 +222,35 @@ export class WorkshopEks extends Construct {
                                         ],
                                         action: 'replace',
                                     },
+                                    // petsite -> Waggle orchestrator. The .NET SDK instrumentation stamps
+                                    // RemoteService 'AWS::Bedrock AgentCore' for InvokeAgentRuntime, so the
+                                    // dependency renders as one shared AWS::Service node instead of an edge
+                                    // to the orchestrator. Naming the real service (and giving it an
+                                    // environment, which is what makes Application Signals treat a
+                                    // dependency as a Service rather than an AWS::Service) joins it to the
+                                    // node the orchestrator's own telemetry already reports. Values must
+                                    // match that node exactly: runtime name + qualifier, env
+                                    // 'bedrock-agentcore:default'. Source of truth for the name is
+                                    // WAGGLE_AI_AGENT_RUNTIMES in lib/stages/applications.ts.
+                                    // Only petsite calls AgentCore from this cluster, so a single
+                                    // RemoteService selector is unambiguous here. The orchestrator's own
+                                    // outbound hops cannot be fixed by any rule: AgentCore Runtime is
+                                    // managed and runs no CloudWatch agent, so those set the attributes
+                                    // in-process instead (see orchestrator_strands/delegate.py).
+                                    {
+                                        selectors: [{ dimension: 'RemoteService', match: '*Bedrock AgentCore*' }],
+                                        replacements: [
+                                            {
+                                                target_dimension: 'RemoteService',
+                                                value: 'WaggleAIOrchestrator.DEFAULT',
+                                            },
+                                            {
+                                                target_dimension: 'RemoteEnvironment',
+                                                value: 'bedrock-agentcore:default',
+                                            },
+                                        ],
+                                        action: 'replace',
+                                    },
                                 ],
                             },
                             kubernetes: {

--- a/src/cdk/lib/microservices/waggle-ai-nutrition-kb.ts
+++ b/src/cdk/lib/microservices/waggle-ai-nutrition-kb.ts
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
  *
  * @packageDocumentation
  */
-import { CfnOutput, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { CfnOutput, FileSystem, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { CfnKnowledgeBase, CfnDataSource } from 'aws-cdk-lib/aws-bedrock';
 import { Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { CfnIndex, CfnVectorBucket } from 'aws-cdk-lib/aws-s3vectors';
@@ -58,14 +58,11 @@ export class WaggleAINutritionKb extends Construct {
             autoDeleteObjects: true,
             removalPolicy: RemovalPolicy.DESTROY,
         });
-        new BucketDeployment(this, 'KbDocs', {
-            sources: [
-                Source.asset(
-                    // Built without `node:path` on purpose: `unicorn/import-style` requires a
-                    // default import, which this package's tsconfig rejects (no `esModuleInterop`).
-                    `${__dirname}/../../../applications/microservices/waggle_ai_agents/rag/knowledge`,
-                ),
-            ],
+        // Built without `node:path` on purpose: `unicorn/import-style` requires a
+        // default import, which this package's tsconfig rejects (no `esModuleInterop`).
+        const knowledgeDirectory = `${__dirname}/../../../applications/microservices/waggle_ai_agents/rag/knowledge`;
+        const kbDocs = new BucketDeployment(this, 'KbDocs', {
+            sources: [Source.asset(knowledgeDirectory)],
             destinationBucket: sourceBucket,
             destinationKeyPrefix: 'nutrition/',
         });
@@ -129,17 +126,25 @@ export class WaggleAINutritionKb extends Construct {
         });
         dataSource.addDependency(kb);
 
-        // --- Initial ingestion (no CFN resource for StartIngestionJob -> custom resource) ---
-        const ingestion = new AwsCustomResource(this, 'Ingestion', {
-            onCreate: {
-                service: 'bedrock-agent',
-                action: 'startIngestionJob',
-                parameters: {
-                    knowledgeBaseId: kb.attrKnowledgeBaseId,
-                    dataSourceId: dataSource.attrDataSourceId,
-                },
-                physicalResourceId: PhysicalResourceId.of(`${kb.attrKnowledgeBaseId}-ingest`),
+        // --- Ingestion (no CFN resource for StartIngestionJob -> custom resource) ---
+        // The hash of the corpus is part of the physical resource id, so editing
+        // rag/knowledge/*.md changes the custom resource, CloudFormation issues an
+        // Update, and onUpdate starts a fresh ingestion job. Without onUpdate the
+        // KB keeps serving whatever the very first deployment indexed.
+        const startIngestion = {
+            service: 'bedrock-agent',
+            action: 'startIngestionJob',
+            parameters: {
+                knowledgeBaseId: kb.attrKnowledgeBaseId,
+                dataSourceId: dataSource.attrDataSourceId,
             },
+            physicalResourceId: PhysicalResourceId.of(
+                `${kb.attrKnowledgeBaseId}-ingest-${FileSystem.fingerprint(knowledgeDirectory)}`,
+            ),
+        };
+        const ingestion = new AwsCustomResource(this, 'Ingestion', {
+            onCreate: startIngestion,
+            onUpdate: startIngestion,
             policy: AwsCustomResourcePolicy.fromStatements([
                 new PolicyStatement({
                     effect: Effect.ALLOW,
@@ -149,6 +154,11 @@ export class WaggleAINutritionKb extends Construct {
             ]),
         });
         ingestion.node.addDependency(dataSource);
+        // Depending only on the data source lets the job race the BucketDeployment
+        // that uploads the corpus: the sync then scans zero documents and the KB
+        // stays empty, so retrieve() returns no hits and the agent silently
+        // answers ungrounded. Wait for the docs to actually be in the bucket.
+        ingestion.node.addDependency(kbDocs);
 
         Utilities.createSsmParameters(
             this,

--- a/src/cdk/lib/microservices/waggle-ai-nutrition-kb.ts
+++ b/src/cdk/lib/microservices/waggle-ai-nutrition-kb.ts
@@ -61,7 +61,7 @@ export class WaggleAINutritionKb extends Construct {
         // Built without `node:path` on purpose: `unicorn/import-style` requires a
         // default import, which this package's tsconfig rejects (no `esModuleInterop`).
         const knowledgeDirectory = `${__dirname}/../../../applications/microservices/waggle_ai_agents/rag/knowledge`;
-        const kbDocs = new BucketDeployment(this, 'KbDocs', {
+        const kbDocuments = new BucketDeployment(this, 'KbDocs', {
             sources: [Source.asset(knowledgeDirectory)],
             destinationBucket: sourceBucket,
             destinationKeyPrefix: 'nutrition/',
@@ -158,7 +158,7 @@ export class WaggleAINutritionKb extends Construct {
         // that uploads the corpus: the sync then scans zero documents and the KB
         // stays empty, so retrieve() returns no hits and the agent silently
         // answers ungrounded. Wait for the docs to actually be in the bucket.
-        ingestion.node.addDependency(kbDocs);
+        ingestion.node.addDependency(kbDocuments);
 
         Utilities.createSsmParameters(
             this,

--- a/src/cdk/package-lock.json
+++ b/src/cdk/package-lock.json
@@ -4687,6 +4687,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -4728,6 +4729,7 @@
             "version": "5.0.9",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
             "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -7539,6 +7541,7 @@
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
             "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.2"
@@ -8355,6 +8358,7 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"


### PR DESCRIPTION
## What

Two fixes to the Waggle AI multi-agent stack:

1. The CloudWatch Application Signals map rendered the agent call chain
   incorrectly, hiding the real service dependencies.
2. The nutrition knowledge base could serve stale or empty content, so the
   nutrition agent answered ungrounded.

## Why

### 1. Application Signals showed the wrong topology

The map is keyed on the `RemoteService` / `RemoteEnvironment` dimension pair.
Two hops in the chain reported values that did not match any real node:

| Hop | Reported as | Rendered as |
|---|---|---|
| petsite to orchestrator | `AWS::Bedrock AgentCore` (stamped by the .NET SDK for `InvokeAgentRuntime`) | one shared generic `AWS::Service` node, not an edge |
| orchestrator to sub-agents | the gateway hostname (from the auto-instrumented HTTP span) | a dead-end node, since the gateway emits no server span |

The result was a map that did not show `petsite -> orchestrator -> sub-agents`
at all, which is the exact dependency path this demo exists to teach.

The two hops need different mechanisms, because only one of them runs a
CloudWatch agent:

- **petsite (EKS):** fixed declaratively with a CloudWatch agent dimension
  replacement rule in `eks.ts`, rewriting `RemoteService` to
  `WaggleAIOrchestrator.DEFAULT` and setting `RemoteEnvironment` to
  `bedrock-agentcore:default`. Supplying an environment is what makes
  Application Signals treat the dependency as a `Service` rather than an
  `AWS::Service`. Only petsite calls AgentCore from this cluster, so a single
  `*Bedrock AgentCore*` selector is unambiguous.
- **orchestrator (AgentCore Runtime):** AgentCore is managed and runs no
  CloudWatch agent, so no rule can reach it. `delegate.py` now opens an
  explicit `CLIENT` span per delegation and sets `aws.remote.service` /
  `aws.remote.environment` in process.

Service names must match the node each sub-agent's own telemetry already
reports, which is the AgentCore runtime name plus qualifier. Source of truth is
`WAGGLE_AI_AGENT_RUNTIMES` in `lib/stages/applications.ts`; a mismatch adds a
node instead of joining an edge. All names are env-var overridable.

### 2. Knowledge base served stale or empty content

Two separate defects in `waggle-ai-nutrition-kb.ts`:

- **Stale:** the ingestion custom resource had `onCreate` only, with a fixed
  physical resource id. Editing `rag/knowledge/*.md` produced no CloudFormation
  change, so the KB kept serving whatever the very first deployment indexed.
  Fixed by folding `FileSystem.fingerprint(knowledgeDirectory)` into the
  physical resource id and adding an `onUpdate` handler, so a corpus edit
  triggers a fresh ingestion job.
- **Empty:** the ingestion job depended only on the data source, letting it
  race the `BucketDeployment` that uploads the corpus. When it won, the sync
  scanned zero documents and the KB stayed empty. Because `retrieve()` returns
  no hits rather than an error, the agent answered ungrounded with no visible
  failure. Fixed with an explicit `addDependency(kbDocs)`.

## Changes

| File | Change |
|---|---|
| `src/cdk/lib/constructs/eks.ts` | CloudWatch agent dimension replacement rule for the petsite to orchestrator hop |
| `.../orchestrator_strands/delegate.py` | `_delegation_span` CLIENT span with remote service/environment attributes; records response status and exceptions |
| `src/cdk/lib/microservices/waggle-ai-nutrition-kb.ts` | Fingerprinted physical resource id, `onUpdate` ingestion, dependency on `BucketDeployment` |

## Notes

- OpenTelemetry import is wrapped in `try/except ImportError` with a `_TRACER is
  None` fallback, so local development without the runtime image still works.
- The delegation span wraps the existing `httpx` call and does not change
  request or response handling. Failures still return the same
  `{"error": ...}` JSON to the orchestrator.
- No new IAM permissions and no new dependencies.