### PR TITLE
Promote staging to main: split lambda test deps from runtime

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -98,7 +98,7 @@ jobs:
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
-                  pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
               working-directory: ${{ matrix.service.path }}
 
             - name: Run tests

--- a/src/applications/lambda/petfood-image-generator-python/requirements-dev.txt
+++ b/src/applications/lambda/petfood-image-generator-python/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0.0

--- a/src/applications/lambda/petfood-image-generator-python/requirements.txt
+++ b/src/applications/lambda/petfood-image-generator-python/requirements.txt
@@ -1,3 +1,1 @@
 strands-agents>=1.10.0
-strands-agents-tools>=0.2.9
-pytest>=8.0.0


### PR DESCRIPTION
## Summary

Promote `staging` into `main` after cleaning up branch drift.

`staging` had diverged from `main` by ~14 commits that were graph-only artifacts: PR #575 was squash-merged into `main`, so `staging`'s original per-commit SHAs read as "ahead" even though their content already landed. On top of that, PR #583 was applied to `staging` and then reverted (#584), leaving apply-then-revert churn. The net tree of `staging` was already identical to `main`.

`staging` was rebuilt fresh off `main` and the single needed change from #583 was cherry-picked back in, so this PR is now a clean one-commit promotion.

## What changed

One commit: `fix(lambda): split test dependencies from runtime package` (author: Raviteja Sunkavalli).

- `src/applications/lambda/petfood-image-generator-python/requirements.txt`: drop `pytest` (and the unused `strands-agents-tools`) from the runtime dependency set, leaving only `strands-agents`.
- `src/applications/lambda/petfood-image-generator-python/requirements-dev.txt` (new): `-r requirements.txt` plus `pytest>=8.0.0`.
- `.github/workflows/build-test.yml`: the test job installs `requirements-dev.txt` instead of `requirements.txt`.

Effect: the Lambda runtime package no longer carries `pytest`, while CI still installs it for the test step.

## Testing

- `build-test.yml` validated as well-formed YAML.
- `pip install --dry-run -r requirements-dev.txt` resolves the full tree including `pytest` (confirms the CI test step will find pytest).
- `py_compile` clean on the lambda source and its test.
- Full workshop validation on `staging` is run by the maintainer before merge.

## Notes

- Diff `main...staging` is exactly the 3 files above.
- Branch history is linear: `main` + one commit.
